### PR TITLE
functions: more reliable systemd detection logic

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -14,7 +14,7 @@ PATH="/sbin:/usr/sbin:/bin:/usr/bin"
 export PATH
 
 if [ $PPID -ne 1 -a -z "$SYSTEMCTL_SKIP_REDIRECT" ] && \
-		( /bin/mountpoint -q /cgroup/systemd || /bin/mountpoint -q /sys/fs/cgroup/systemd ) ; then
+		[ -d /run/systemd/system ] ; then
         case "$0" in
         /etc/init.d/*|/etc/rc.d/init.d/*)
 		_use_systemctl=1


### PR DESCRIPTION
On cgroup2 systems the current test for systemd doesn't work, as the cgroup hierarchy is setup differently. This results in the `systemctl_redirect` function not working properly, which breaks the redirection logic and leads to subtle bugs and general sadness. This PR changes the logic to just check for `/run/systemd/system`, which is independent from the cgroup hierarchy and is the recommended way to detect systemd by upstream.