### PR TITLE
Provide a mechanism to prevent network-scripts from messing with sysctls

### DIFF
--- a/sysconfig/network-scripts/ifdown-ipv6
+++ b/sysconfig/network-scripts/ifdown-ipv6
@@ -62,10 +62,12 @@ if [ $? != 0 -a $? != 11 ]; then
 	exit 1
 fi
 
-# Switch some sysctls to secure mode
-/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=0 >/dev/null 2>&1
-/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=0 >/dev/null 2>&1
-/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=0 >/dev/null 2>&1
+if [ ! "$IPV6_SET_SYCTL" = "no" ]; then
+  # Switch some sysctls to secure mode
+  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=0 >/dev/null 2>&1
+  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=0 >/dev/null 2>&1
+  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=0 >/dev/null 2>&1
+fi
 /sbin/ip link set $DEVICE addrgenmode eui64 >/dev/null 2>&1
 
 # Test status of tun6to4 device

--- a/sysconfig/network-scripts/ifup-ipv6
+++ b/sysconfig/network-scripts/ifup-ipv6
@@ -127,10 +127,13 @@ else
                 ipv6_local_accept_ra=0
 	fi
 fi
-/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=$ipv6_local_forwarding >/dev/null 2>&1
-/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=$ipv6_local_accept_ra >/dev/null 2>&1
-/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=$ipv6_local_auto >/dev/null 2>&1
-/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.autoconf=$ipv6_local_auto >/dev/null 2>&1
+
+if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
+  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=$ipv6_local_forwarding >/dev/null 2>&1
+  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=$ipv6_local_accept_ra >/dev/null 2>&1
+  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=$ipv6_local_auto >/dev/null 2>&1
+  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.autoconf=$ipv6_local_auto >/dev/null 2>&1
+fi
 
 # Set IPv6 MTU, if given
 if [ -n "$IPV6_MTU" ]; then
@@ -146,10 +149,12 @@ fi
 
 # Enable IPv6 RFC3041 privacy extensions if desired
 if [ "$IPV6_PRIVACY" = "rfc3041" ]; then
-	/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.use_tempaddr=2 >/dev/null 2>&1
-	if [ $? -ne 0 ]; then
-		net_log $"Cannot enable IPv6 privacy method '$IPV6_PRIVACY', not supported by kernel"
-	fi
+  if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
+	  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.use_tempaddr=2 >/dev/null 2>&1
+  	if [ $? -ne 0 ]; then
+		  net_log $"Cannot enable IPv6 privacy method '$IPV6_PRIVACY', not supported by kernel"
+	  fi
+  fi
 fi
 
 # Setup default IPv6 route, check are done by function

--- a/sysconfig/network-scripts/init.ipv6-global
+++ b/sysconfig/network-scripts/init.ipv6-global
@@ -28,8 +28,6 @@
 #  IPV6_DEFAULTDEV=<interface> [optional]
 #
 
-
-
 . /etc/sysconfig/network
 
 cd /etc/sysconfig/network-scripts
@@ -64,16 +62,18 @@ case $ACTION in
 		fi
 
 		# Reset IPv6 sysctl switches for "all", "default" and still existing devices
-		for i in /proc/sys/net/ipv6/conf/* ; do
-			interface=${i##*/}
-			sinterface=${interface/.//}
-			# Host/Router behaviour for the interface
-			/sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=$ipv6_global_forwarding >/dev/null 2>&1
+    if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
+      for i in /proc/sys/net/ipv6/conf/* ; do
+        interface=${i##*/}
+        sinterface=${interface/.//}
+        # Host/Router behaviour for the interface
+        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=$ipv6_global_forwarding >/dev/null 2>&1
 
-			# Autoconfiguration and redirect handling for Hosts
-			/sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=$ipv6_global_auto >/dev/null 2>&1
-			/sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=$ipv6_global_auto >/dev/null 2>&1
-		done
+        # Autoconfiguration and redirect handling for Hosts
+        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=$ipv6_global_auto >/dev/null 2>&1
+        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=$ipv6_global_auto >/dev/null 2>&1
+      done
+    fi
 		;;
 
 	    post)
@@ -131,16 +131,18 @@ case $ACTION in
 		ipv6_test testonly || exit 0
 
 
-		for i in /proc/sys/net/ipv6/conf/* ; do
-			interface=${i##*/}
-			sinterface=${interface/.//}
-			# Assume Host behaviour
-			/sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=0 >/dev/null 2>&1
+    if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
+      for i in /proc/sys/net/ipv6/conf/* ; do
+        interface=${i##*/}
+        sinterface=${interface/.//}
+        # Assume Host behaviour
+        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=0 >/dev/null 2>&1
 
-			# Disable autoconfiguration and redirects
-			/sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=0 >/dev/null 2>&1
-			/sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=0 >/dev/null 2>&1
-		done
+        # Disable autoconfiguration and redirects
+        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=0 >/dev/null 2>&1
+        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=0 >/dev/null 2>&1
+      done
+    fi
 
 		# Cleanup still existing tunnel devices
 		ipv6_cleanup_tunnel_devices


### PR DESCRIPTION
network-scripts makes odd assumptions, like if I don't want SLAAC (i.e.
if I turn off AUTOCONF) that I also don't want RA. This is not true,
it's common to have a static local address, but to get my gateway
through RA.

This is one solution. I will also be sending a more specific solution to
enable the above directly, but having a way to tell network-scripts
to not mess with systctls seems generally useful.