### PR TITLE
[1/3] Remove tabs and fix spacing: ipv6 scripts

### DIFF
--- a/sysconfig/network-scripts/ifdown-ipv6
+++ b/sysconfig/network-scripts/ifdown-ipv6
@@ -58,80 +58,81 @@ ipv6_test testonly || exit 0
 # Test device status
 ipv6_test_device_status $DEVICE
 if [ $? != 0 -a $? != 11 ]; then
-	# device doesn't exist or other problem occurs
-	exit 1
+    # device doesn't exist or other problem occurs
+    exit 1
 fi
 
 if [ ! "$IPV6_SET_SYCTL" = "no" ]; then
-  # Switch some sysctls to secure mode
-  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=0 >/dev/null 2>&1
-  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=0 >/dev/null 2>&1
-  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=0 >/dev/null 2>&1
+    # Switch some sysctls to secure mode
+    /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=0 >/dev/null 2>&1
+    /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=0 >/dev/null 2>&1
+    /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=0 >/dev/null 2>&1
 fi
 /sbin/ip link set $DEVICE addrgenmode eui64 >/dev/null 2>&1
 
 # Test status of tun6to4 device
 ipv6_test_device_status tun6to4
 if [ $? = 0 -o $? = 11 ]; then
-	# Device exists
-	valid6to4config="yes"
+    # Device exists
+    valid6to4config="yes"
 
-	if [ -z "$IPV6TO4_RELAY" ]; then
-		IPV6TO4_RELAY="192.88.99.1"
-	fi
+    if [ -z "$IPV6TO4_RELAY" ]; then
+        IPV6TO4_RELAY="192.88.99.1"
+    fi
 
-	# Get IPv4 address from interface
-	if [ -n "$IPV6TO4_IPV4ADDR" ]; then
-		# Take special configured from config file (precedence 1)
-		ipv4addr="$IPV6TO4_IPV4ADDR"
+    # Get IPv4 address from interface
+    if [ -n "$IPV6TO4_IPV4ADDR" ]; then
+        # Take special configured from config file (precedence 1)
+        ipv4addr="$IPV6TO4_IPV4ADDR"
 
-		# Get IPv4 address from interface first
-		ipv4addrlocal="$(ipv6_get_ipv4addr_of_device $DEVICE)"
-		if [ -z "$ipv4addrlocal" ]; then
-			# Take configured from config file
-			ipv4addrlocal="$IPADDR"
-		fi
-	else
-		# Get IPv4 address from interface first (has precedence 2)
-		ipv4addr="$(ipv6_get_ipv4addr_of_device $DEVICE)"
-		if [ -z "$ipv4addr" ]; then
-			# Take configured from config file (precedence 3)
-			ipv4addr="$IPADDR"
-		fi
-		ipv4addrlocal="$ipv4addr"
-	fi
+        # Get IPv4 address from interface first
+        ipv4addrlocal="$(ipv6_get_ipv4addr_of_device $DEVICE)"
+        if [ -z "$ipv4addrlocal" ]; then
+            # Take configured from config file
+            ipv4addrlocal="$IPADDR"
+        fi
+    else
+        # Get IPv4 address from interface first (has precedence 2)
+        ipv4addr="$(ipv6_get_ipv4addr_of_device $DEVICE)"
+        if [ -z "$ipv4addr" ]; then
+            # Take configured from config file (precedence 3)
+            ipv4addr="$IPADDR"
+        fi
+        ipv4addrlocal="$ipv4addr"
+    fi
 
-	# Get local IPv4 address of dedicated tunnel
-	ipv4addr6to4local="$(ipv6_get_ipv4addr_of_tunnel tun6to4 local)"
+    # Get local IPv4 address of dedicated tunnel
+    ipv4addr6to4local="$(ipv6_get_ipv4addr_of_tunnel tun6to4 local)"
 
-	if [ -z "$ipv4addrlocal" -o -z "$ipv4addr6to4local" ]; then
-		# no IPv4 addresses given, 6to4 sure not configured
-		valid6to4config="no"
-	else
-		# Check against configured 6to4 tunnel to see if this interface was used before
-		if [ "$ipv4addrlocal" != "$ipv4addr6to4local" ]; then
-			# IPv4 address of interface does't match local tunnel address, interface was not used for current 6to4 setup
-			valid6to4config="no"
-		fi
-	fi
-
+    if [ -z "$ipv4addrlocal" -o -z "$ipv4addr6to4local" ]; then
+        # no IPv4 addresses given, 6to4 sure not configured
+        valid6to4config="no"
+    else
+        # Check against configured 6to4 tunnel to see if this interface was
+        # used before
+        if [ "$ipv4addrlocal" != "$ipv4addr6to4local" ]; then
+            # IPv4 address of interface does't match local tunnel address,
+            # interface was not used for current 6to4 setup
+            valid6to4config="no"
+        fi
+    fi
 fi
 
 # Shutdown of 6to4, if configured
 if [ "$valid6to4config" = "yes" ]; then
-	if [ -n "$IPV6TO4_ROUTING" ]; then
-		# Delete routes to local networks
-		for devsuf in $IPV6TO4_ROUTING; do
-			dev="${devsuf%%-*}"
-			ipv6_cleanup_6to4_device $dev
-		done
-	fi
+    if [ -n "$IPV6TO4_ROUTING" ]; then
+        # Delete routes to local networks
+        for devsuf in $IPV6TO4_ROUTING; do
+            dev="${devsuf%%-*}"
+            ipv6_cleanup_6to4_device $dev
+        done
+    fi
 
-	# Delete all configured 6to4 address
-	ipv6_cleanup_6to4_tunnels tun6to4
+    # Delete all configured 6to4 address
+    ipv6_cleanup_6to4_tunnels tun6to4
 
-	# Control running radvd
-	ipv6_trigger_radvd down "$IPV6_RADVD_TRIGGER_ACTION" $IPV6_RADVD_PIDFILE
+    # Control running radvd
+    ipv6_trigger_radvd down "$IPV6_RADVD_TRIGGER_ACTION" $IPV6_RADVD_PIDFILE
 fi
 
 # Delete all current configured IPv6 addresses on this interface

--- a/sysconfig/network-scripts/ifup-ipv6
+++ b/sysconfig/network-scripts/ifup-ipv6
@@ -78,13 +78,13 @@ ipv6_test || exit 1
 # Test device status
 ipv6_test_device_status $DEVICE
 if [ $? != 0 -a $? != 11 ]; then
-	# device doesn't exist or other problem occurs
-	exit 1
+    # device doesn't exist or other problem occurs
+    exit 1
 fi
 
 # Setup IPv6 address on specified interface
 if [ -n "$IPV6ADDR" ]; then
-	ipv6_add_addr_on_device $DEVICE $IPV6ADDR || exit 1
+    ipv6_add_addr_on_device $DEVICE $IPV6ADDR || exit 1
 fi
 
 # Get current global IPv6 forwarding
@@ -92,224 +92,224 @@ ipv6_global_forwarding_current="$(/sbin/sysctl -e -n net.ipv6.conf.all.forwardin
 
 # Set some proc switches depending on defines
 if [ "$IPV6FORWARDING" = "yes" ]; then
-	# Global forwarding should be enabled
+    # Global forwarding should be enabled
 
-	# Check, if global IPv6 forwarding was already set by global script
-	if [ $ipv6_global_forwarding_current -ne 1 ]; then
-		net_log $"Global IPv6 forwarding is enabled in configuration, but not currently enabled in kernel"
-		net_log $"Please restart network with '/sbin/service network restart'"
-	fi
-
-	ipv6_local_forwarding=1
-	ipv6_local_auto=0
-        ipv6_local_accept_ra=0
-	if [ "$IPV6_ROUTER" = "no" ]; then
-		ipv6_local_forwarding=0
-	fi
-	if [ "$IPV6_AUTOCONF" = "yes" ]; then
-		ipv6_local_auto=1
-                ipv6_local_accept_ra=2
-	fi
-else
-	# Global forwarding should be disabled
-
-	# Check, if global IPv6 forwarding was already set by global script
-	if [ $ipv6_global_forwarding_current -ne 0 ]; then
-		net_log $"Global IPv6 forwarding is disabled in configuration, but not currently disabled in kernel"
-		net_log $"Please restart network with '/sbin/service network restart'"
-	fi
-
-	ipv6_local_forwarding=0
-	ipv6_local_auto=1
-        ipv6_local_accept_ra=1
-	if [ "$IPV6_AUTOCONF" = "no" ]; then
-		ipv6_local_auto=0
-    if [ ! "$IPV6_FORCE_ACCEPT_RA" = "yes" ]; then
-      ipv6_local_accept_ra=0
+    # Check, if global IPv6 forwarding was already set by global script
+    if [ $ipv6_global_forwarding_current -ne 1 ]; then
+        net_log $"Global IPv6 forwarding is enabled in configuration, but not currently enabled in kernel"
+        net_log $"Please restart network with '/sbin/service network restart'"
     fi
-	fi
+
+    ipv6_local_forwarding=1
+    ipv6_local_auto=0
+    ipv6_local_accept_ra=0
+    if [ "$IPV6_ROUTER" = "no" ]; then
+        ipv6_local_forwarding=0
+    fi
+    if [ "$IPV6_AUTOCONF" = "yes" ]; then
+        ipv6_local_auto=1
+        ipv6_local_accept_ra=2
+    fi
+else
+    # Global forwarding should be disabled
+
+    # Check, if global IPv6 forwarding was already set by global script
+    if [ $ipv6_global_forwarding_current -ne 0 ]; then
+        net_log $"Global IPv6 forwarding is disabled in configuration, but not currently disabled in kernel"
+        net_log $"Please restart network with '/sbin/service network restart'"
+    fi
+
+    ipv6_local_forwarding=0
+    ipv6_local_auto=1
+    ipv6_local_accept_ra=1
+    if [ "$IPV6_AUTOCONF" = "no" ]; then
+        ipv6_local_auto=0
+        if [ ! "$IPV6_FORCE_ACCEPT_RA" = "yes" ]; then
+            ipv6_local_accept_ra=0
+        fi
+    fi
 fi
 
 if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
-  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=$ipv6_local_forwarding >/dev/null 2>&1
-  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=$ipv6_local_accept_ra >/dev/null 2>&1
-  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=$ipv6_local_auto >/dev/null 2>&1
-  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.autoconf=$ipv6_local_auto >/dev/null 2>&1
+    /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=$ipv6_local_forwarding >/dev/null 2>&1
+    /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=$ipv6_local_accept_ra >/dev/null 2>&1
+    /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=$ipv6_local_auto >/dev/null 2>&1
+    /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.autoconf=$ipv6_local_auto >/dev/null 2>&1
 fi
 
 # Set IPv6 MTU, if given
 if [ -n "$IPV6_MTU" ]; then
-	ipv6_set_mtu $DEVICE $IPV6_MTU
+    ipv6_set_mtu $DEVICE $IPV6_MTU
 fi
 
 # Setup additional IPv6 addresses from list, if given
 if [ -n "$IPV6ADDR_SECONDARIES" ]; then
-	for ipv6addr in $IPV6ADDR_SECONDARIES; do
-		ipv6_add_addr_on_device $DEVICE $ipv6addr
-	done
+    for ipv6addr in $IPV6ADDR_SECONDARIES; do
+        ipv6_add_addr_on_device $DEVICE $ipv6addr
+    done
 fi
 
 # Enable IPv6 RFC3041 privacy extensions if desired
 if [ "$IPV6_PRIVACY" = "rfc3041" ]; then
-  if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
-	  /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.use_tempaddr=2 >/dev/null 2>&1
-  	if [ $? -ne 0 ]; then
-		  net_log $"Cannot enable IPv6 privacy method '$IPV6_PRIVACY', not supported by kernel"
-	  fi
-  fi
+    if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
+        /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.use_tempaddr=2 >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            net_log $"Cannot enable IPv6 privacy method '$IPV6_PRIVACY', not supported by kernel"
+        fi
+    fi
 fi
 
 # Setup default IPv6 route, check are done by function
 if [ -n "$IPV6_DEFAULTDEV" -o -n "$IPV6_DEFAULTGW" ]; then
-	ipv6_set_default_route "$IPV6_DEFAULTGW" "$IPV6_DEFAULTDEV" "$DEVICE"
+    ipv6_set_default_route "$IPV6_DEFAULTGW" "$IPV6_DEFAULTDEV" "$DEVICE"
 fi
 
 # Setup additional static IPv6 routes on specified interface, if given
 if [ -f /etc/sysconfig/static-routes-ipv6 ]; then
-	LC_ALL=C grep -w "^$DEVICE" /etc/sysconfig/static-routes-ipv6 | while read device args; do
-		ipv6_add_route $args $DEVICE
-	done
+    LC_ALL=C grep -w "^$DEVICE" /etc/sysconfig/static-routes-ipv6 | while read device args; do
+        ipv6_add_route $args $DEVICE
+    done
 fi
 
 # Setup of 6to4, if configured
 if [ "$IPV6TO4INIT" = "yes" ]; then
-	valid6to4config="yes"
+    valid6to4config="yes"
 
-	# Test device status of 6to4 tunnel
-	ipv6_test_device_status tun6to4
-	if [ $? = 0 ]; then
-		# device is already up
-		net_log $"Device 'tun6to4' (from '$DEVICE') is already up, shutdown first"
-		exit 1
-	fi
+    # Test device status of 6to4 tunnel
+    ipv6_test_device_status tun6to4
+    if [ $? = 0 ]; then
+        # device is already up
+        net_log $"Device 'tun6to4' (from '$DEVICE') is already up, shutdown first"
+        exit 1
+    fi
 
-	# Get IPv4 address for global 6to4 prefix calculation
-	if [ -n "$IPV6TO4_IPV4ADDR" ]; then
-		# Take special configured from config file (precedence 1)
-		ipv4addr="$IPV6TO4_IPV4ADDR"
+    # Get IPv4 address for global 6to4 prefix calculation
+    if [ -n "$IPV6TO4_IPV4ADDR" ]; then
+        # Take special configured from config file (precedence 1)
+        ipv4addr="$IPV6TO4_IPV4ADDR"
 
-		# Get local IPv4 address from interface
-		ipv4addrlocal="$(ipv6_get_ipv4addr_of_device $DEVICE)"
-		if [ -z "$ipv4addrlocal" ]; then
-			# Take configured from config file
-			ipv4addrlocal="$IPADDR"
-		fi
-        else
-		# Get IPv4 address from interface first (has precedence 2)
-		ipv4addr="$(ipv6_get_ipv4addr_of_device $DEVICE)"
-		if [ -z "$ipv4addr" ]; then
-			# Take configured from config file (precedence 3)
-			ipv4addr="$IPADDR"
-		fi
-		ipv4addrlocal="$ipv4addr"
+        # Get local IPv4 address from interface
+        ipv4addrlocal="$(ipv6_get_ipv4addr_of_device $DEVICE)"
+        if [ -z "$ipv4addrlocal" ]; then
+            # Take configured from config file
+            ipv4addrlocal="$IPADDR"
+        fi
+    else
+        # Get IPv4 address from interface first (has precedence 2)
+        ipv4addr="$(ipv6_get_ipv4addr_of_device $DEVICE)"
+        if [ -z "$ipv4addr" ]; then
+            # Take configured from config file (precedence 3)
+            ipv4addr="$IPADDR"
+        fi
+        ipv4addrlocal="$ipv4addr"
+    fi
+
+    if [ -n "$ipv4addr" ]; then
+        if ! ipv6_test_ipv4_addr_global_usable $ipv4addr; then
+            net_log $"Given IPv4 address '$ipv4addr' is not globally usable" info
+            valid6to4config="no"
+        fi
+        if [ -z "$IPV6TO4_RELAY" ]; then
+            IPV6TO4_RELAY="192.88.99.1"
         fi
 
-	if [ -n "$ipv4addr" ]; then
-		if ! ipv6_test_ipv4_addr_global_usable $ipv4addr; then
-			net_log $"Given IPv4 address '$ipv4addr' is not globally usable" info
-	                valid6to4config="no"
-        	fi
-		if [ -z "$IPV6TO4_RELAY" ]; then
-			IPV6TO4_RELAY="192.88.99.1"
-		fi
-
-		# Check/generate relay address
-		ipv6to4_relay="$(ipv6_create_6to4_relay_address $IPV6TO4_RELAY)"
-		if [ $? -ne 0 ]; then
-			valid6to4config="no"
-		fi
-	else
-        	net_log $"IPv6to4 configuration needs an IPv4 address on related interface or otherwise specified" info
-		valid6to4config="no"
-	fi
-
-	# Setup 6to4 tunnel (hardwired name is "tun6to4"), if config is valid
-        if [ "$valid6to4config" = "yes" ]; then
-		# Get MTU of master device
-		ipv4mtu="$(/sbin/ip link show dev $DEVICE | awk '/\<mtu\>/ { print $5 }')"
-		if [ -n "$ipv4mtu" ]; then
-			# IPv6 tunnel MTU is IPv4 MTU minus 20 for IPv4 header
-			tunnelmtu=$(($ipv4mtu-20))
-		fi
-
-		if [ -n "$IPV6TO4_MTU" ]; then
-			if [ $IPV6TO4_MTU -gt $tunnelmtu ]; then
-				net_log $"Warning: configured MTU '$IPV6TO4_MTU' for 6to4 exceeds maximum limit of '$tunnelmtu', ignored" warning
-			else
-				tunnelmtu=$IPV6TO4_MTU
-			fi
-		fi
-
-		ipv6_add_6to4_tunnel tun6to4 $ipv4addr "" $tunnelmtu $ipv4addrlocal || exit 1
-
-		# Add route to for compatible addresses (removed later again)
-		ipv6_add_route "::/96" "::" tun6to4
-
-		# Add default route, if device matches
-		if [ "$IPV6_DEFAULTDEV" = "tun6to4" ]; then
-			if [ -n "$IPV6_DEFAULTGW" ]; then
-				net_log $"Warning: interface 'tun6to4' does not support 'IPV6_DEFAULTGW', ignored" warning
-			fi
-			ipv6_set_default_route $ipv6to4_relay tun6to4
-		fi
-
-		# Add static routes
-		if [ -f /etc/sysconfig/static-routes-ipv6 ]; then
-			LC_ALL=C grep -w "^tun6to4" /etc/sysconfig/static-routes-ipv6 | while read device network gateway; do
-				if [ -z "$network" ]; then
-					continue
-				fi
-				if [ -z "$gateway" ]; then
-					gateway="$ipv6to4_relay"
-				fi
-				ipv6_add_route $network $gateway tun6to4
-			done
-		fi
-
-		# Setup additional static IPv6 routes (newer config style)
-		if [ -f "/etc/sysconfig/network-scripts/route6-tun6to4" ]; then
-			sed -ne 's/#.*//' -e '/[^[:space:]]/p' /etc/sysconfig/network-scripts/route6-tun6to4 | while read line; do
-				if echo "$line" | LC_ALL=C grep -vq 'via'; then
-					# Add gateway if missing
-					line="$line via $ipv6to4_relay"
-				fi
-				/sbin/ip -6 route add $line
-			done
-		fi
-
-		# Cleanup autmatically generated autotunnel (not needed for 6to4)
-		/sbin/ip -6 route del ::/96 dev tun6to4
-		/sbin/ip -6 addr del "::$ipv4addrlocal/128" dev tun6to4
-
-	        if [ "$IPV6_CONTROL_RADVD" = "yes" ]; then
-			# RADVD is in use, so forwarding of IPv6 packets should be enabled, display warning
-			if [ $ipv6_global_forwarding_current -ne 1 ]; then
-				net_log $"Using 6to4 and RADVD IPv6 forwarding usually should be enabled, but it isn't" warning
-			fi
-
-		        if [ -n "$IPV6TO4_ROUTING" ]; then
-				ipv6to4prefix="$(ipv6_create_6to4_prefix $ipv4addr)"
-				if [ -n "$ipv6to4prefix" ]; then
-					# Add route to local networks
-					for devsuf in $IPV6TO4_ROUTING; do
-						dev="${devsuf%%-*}"
-						suf="$(echo $devsuf | awk -F- '{ print $2 }')"
-						ipv6_add_addr_on_device ${dev} ${ipv6to4prefix}${suf}
-					done
-				else
-					net_log $"Error occurred while calculating the IPv6to4 prefix"
-				fi
-			else
-				net_log $"radvd control enabled, but config is not complete"
-			fi
-
-			# Control running radvd
-			ipv6_trigger_radvd up "$IPV6_RADVD_TRIGGER_ACTION" $IPV6_RADVD_PIDFILE
-		fi
-	else
-		net_log $"6to4 configuration is not valid"
-		exit 1
+        # Check/generate relay address
+        ipv6to4_relay="$(ipv6_create_6to4_relay_address $IPV6TO4_RELAY)"
+        if [ $? -ne 0 ]; then
+            valid6to4config="no"
         fi
+    else
+        net_log $"IPv6to4 configuration needs an IPv4 address on related interface or otherwise specified" info
+        valid6to4config="no"
+    fi
+
+    # Setup 6to4 tunnel (hardwired name is "tun6to4"), if config is valid
+    if [ "$valid6to4config" = "yes" ]; then
+        # Get MTU of master device
+        ipv4mtu="$(/sbin/ip link show dev $DEVICE | awk '/\<mtu\>/ { print $5 }')"
+        if [ -n "$ipv4mtu" ]; then
+            # IPv6 tunnel MTU is IPv4 MTU minus 20 for IPv4 header
+            tunnelmtu=$(($ipv4mtu-20))
+        fi
+
+        if [ -n "$IPV6TO4_MTU" ]; then
+            if [ $IPV6TO4_MTU -gt $tunnelmtu ]; then
+                net_log $"Warning: configured MTU '$IPV6TO4_MTU' for 6to4 exceeds maximum limit of '$tunnelmtu', ignored" warning
+            else
+                tunnelmtu=$IPV6TO4_MTU
+            fi
+        fi
+
+        ipv6_add_6to4_tunnel tun6to4 $ipv4addr "" $tunnelmtu $ipv4addrlocal || exit 1
+
+        # Add route to for compatible addresses (removed later again)
+        ipv6_add_route "::/96" "::" tun6to4
+
+        # Add default route, if device matches
+        if [ "$IPV6_DEFAULTDEV" = "tun6to4" ]; then
+            if [ -n "$IPV6_DEFAULTGW" ]; then
+                net_log $"Warning: interface 'tun6to4' does not support 'IPV6_DEFAULTGW', ignored" warning
+            fi
+            ipv6_set_default_route $ipv6to4_relay tun6to4
+        fi
+
+        # Add static routes
+        if [ -f /etc/sysconfig/static-routes-ipv6 ]; then
+            LC_ALL=C grep -w "^tun6to4" /etc/sysconfig/static-routes-ipv6 | while read device network gateway; do
+                if [ -z "$network" ]; then
+                    continue
+                fi
+                if [ -z "$gateway" ]; then
+                    gateway="$ipv6to4_relay"
+                fi
+                ipv6_add_route $network $gateway tun6to4
+            done
+        fi
+
+        # Setup additional static IPv6 routes (newer config style)
+        if [ -f "/etc/sysconfig/network-scripts/route6-tun6to4" ]; then
+            sed -ne 's/#.*//' -e '/[^[:space:]]/p' /etc/sysconfig/network-scripts/route6-tun6to4 | while read line; do
+                if echo "$line" | LC_ALL=C grep -vq 'via'; then
+                    # Add gateway if missing
+                    line="$line via $ipv6to4_relay"
+                fi
+                /sbin/ip -6 route add $line
+            done
+        fi
+
+        # Cleanup autmatically generated autotunnel (not needed for 6to4)
+        /sbin/ip -6 route del ::/96 dev tun6to4
+        /sbin/ip -6 addr del "::$ipv4addrlocal/128" dev tun6to4
+
+        if [ "$IPV6_CONTROL_RADVD" = "yes" ]; then
+            # RADVD is in use, so forwarding of IPv6 packets should be enabled, display warning
+            if [ $ipv6_global_forwarding_current -ne 1 ]; then
+                net_log $"Using 6to4 and RADVD IPv6 forwarding usually should be enabled, but it isn't" warning
+            fi
+
+            if [ -n "$IPV6TO4_ROUTING" ]; then
+                ipv6to4prefix="$(ipv6_create_6to4_prefix $ipv4addr)"
+                if [ -n "$ipv6to4prefix" ]; then
+                    # Add route to local networks
+                    for devsuf in $IPV6TO4_ROUTING; do
+                        dev="${devsuf%%-*}"
+                        suf="$(echo $devsuf | awk -F- '{ print $2 }')"
+                        ipv6_add_addr_on_device ${dev} ${ipv6to4prefix}${suf}
+                    done
+                else
+                    net_log $"Error occurred while calculating the IPv6to4 prefix"
+                fi
+            else
+                net_log $"radvd control enabled, but config is not complete"
+            fi
+
+            # Control running radvd
+            ipv6_trigger_radvd up "$IPV6_RADVD_TRIGGER_ACTION" $IPV6_RADVD_PIDFILE
+        fi
+    else
+        net_log $"6to4 configuration is not valid"
+        exit 1
+    fi
 fi
 
 #wait for all global IPv6 addresses to leave the "tentative" state

--- a/sysconfig/network-scripts/init.ipv6-global
+++ b/sysconfig/network-scripts/init.ipv6-global
@@ -42,126 +42,123 @@ POSITION="$2"
 
 # Initialize IPv6, depending on caller option
 case $ACTION in
-    start)
-	case $POSITION in
-	    pre)
-		# IPv6 test, module loaded, exit if system is not IPv6-ready
-		ipv6_test || exit 1
+start)
+    case $POSITION in
+    pre)
+        # IPv6 test, module loaded, exit if system is not IPv6-ready
+        ipv6_test || exit 1
 
+        if [ "$IPV6FORWARDING" = "yes" ]; then
+            ipv6_global_forwarding=1
+            ipv6_global_auto=0
+        else
+            ipv6_global_forwarding=0
+            if [ "$IPV6_AUTOCONF" = "no" ]; then
+                ipv6_global_auto=0
+            else
+                ipv6_global_auto=1
+            fi
+        fi
 
-		if [ "$IPV6FORWARDING" = "yes" ]; then
-			ipv6_global_forwarding=1
-			ipv6_global_auto=0
-		else
-			ipv6_global_forwarding=0
-			if [ "$IPV6_AUTOCONF" = "no" ]; then
-				ipv6_global_auto=0
-			else
-				ipv6_global_auto=1
-			fi
-		fi
+        if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
+            # Reset IPv6 sysctl switches for "all", "default" and still existing devices
+            for i in /proc/sys/net/ipv6/conf/* ; do
+                interface=${i##*/}
+                sinterface=${interface/.//}
+                # Host/Router behaviour for the interface
+                /sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=$ipv6_global_forwarding >/dev/null 2>&1
 
-		# Reset IPv6 sysctl switches for "all", "default" and still existing devices
-    if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
-      for i in /proc/sys/net/ipv6/conf/* ; do
-        interface=${i##*/}
-        sinterface=${interface/.//}
-        # Host/Router behaviour for the interface
-        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=$ipv6_global_forwarding >/dev/null 2>&1
+                # Autoconfiguration and redirect handling for Hosts
+                /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=$ipv6_global_auto >/dev/null 2>&1
+                /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=$ipv6_global_auto >/dev/null 2>&1
+            done
+        fi
+        ;;
 
-        # Autoconfiguration and redirect handling for Hosts
-        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=$ipv6_global_auto >/dev/null 2>&1
-        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=$ipv6_global_auto >/dev/null 2>&1
-      done
-    fi
-		;;
+    post)
+        # IPv6 test, module loaded, exit if system is not IPv6-ready
+        ipv6_test || exit 1
 
-	    post)
-		# IPv6 test, module loaded, exit if system is not IPv6-ready
-		ipv6_test || exit 1
+        if [ "$IPV6_AUTOTUNNEL" = "yes" ]; then
+            ipv6_enable_autotunnel
+            # autotunnel interface doesn't require a MTU setup
+        fi
 
+        ## Add some routes which should never appear on the wire
+        # Unreachable IPv4-only addresses, normally blocked by source address selection
+        /sbin/ip route add unreach    ::ffff:0.0.0.0/96
+        # Unreachable IPv4-mapped addresses
+        /sbin/ip route add unreach    ::0.0.0.0/96
+        # Unreachable 6to4: IPv4 multicast, reserved, limited broadcast
+        /sbin/ip route add unreach    2002:e000::/19
+        # Unreachable 6to4: IPv4 loopback
+        /sbin/ip route add unreach    2002:7f00::/24
+        # Unreachable 6to4: IPv4 private (RFC 1918)
+        /sbin/ip route add unreach    2002:0a00::/24
+        /sbin/ip route add unreach    2002:ac10::/28
+        /sbin/ip route add unreach    2002:c0a8::/32
+        # Unreachable 6to4: IPv4 private (APIPA / DHCP link-local)
+        /sbin/ip route add unreach    2002:a9fe::/32
+        # Unreachable IPv6: 6bone test addresses
+        /sbin/ip route add unreach    3ffe:ffff::/32
 
-		if [ "$IPV6_AUTOTUNNEL" = "yes" ]; then
-			ipv6_enable_autotunnel
-			# autotunnel interface doesn't require a MTU setup
-		fi
-
-		## Add some routes which should never appear on the wire
-		# Unreachable IPv4-only addresses, normally blocked by source address selection
-		/sbin/ip route add unreach  ::ffff:0.0.0.0/96
-		# Unreachable IPv4-mapped addresses
-		/sbin/ip route add unreach  ::0.0.0.0/96
-		# Unreachable 6to4: IPv4 multicast, reserved, limited broadcast
-		/sbin/ip route add unreach  2002:e000::/19
-		# Unreachable 6to4: IPv4 loopback
-		/sbin/ip route add unreach  2002:7f00::/24
-		# Unreachable 6to4: IPv4 private (RFC 1918)
-		/sbin/ip route add unreach  2002:0a00::/24
-		/sbin/ip route add unreach  2002:ac10::/28
-		/sbin/ip route add unreach  2002:c0a8::/32
-		# Unreachable 6to4: IPv4 private (APIPA / DHCP link-local)
-		/sbin/ip route add unreach  2002:a9fe::/32
-		# Unreachable IPv6: 6bone test addresses
-		/sbin/ip route add unreach  3ffe:ffff::/32
-
-		# Set default route for autotunnel, if specified
-		if [ "$IPV6_DEFAULTDEV" = "sit0" -a "$IPV6_AUTOTUNNEL" = "yes" ]; then
-			if [ -n "$IPV6_DEFAULTGW" ]; then
-				ipv6_set_default_route $IPV6_DEFAULTGW $IPV6_DEFAULTDEV sit0
-			elif [ -n "$IPV6_DEFAULTDEV" ]; then
-				ipv6_set_default_route "" $IPV6_DEFAULTDEV sit0
-			fi
-		fi
-		;;
-
-	    *)
-		echo "Usage: $0 $1 {pre|post}"
-		;;
-
-	esac
-	;;
-
-    stop)
-	case $POSITION in
-	    pre)
-		;;
-
-	    post)
-		# IPv6 test, no module loaded, exit if system is not IPv6-ready
-		ipv6_test testonly || exit 0
-
-
-    if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
-      for i in /proc/sys/net/ipv6/conf/* ; do
-        interface=${i##*/}
-        sinterface=${interface/.//}
-        # Assume Host behaviour
-        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=0 >/dev/null 2>&1
-
-        # Disable autoconfiguration and redirects
-        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=0 >/dev/null 2>&1
-        /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=0 >/dev/null 2>&1
-      done
-    fi
-
-		# Cleanup still existing tunnel devices
-		ipv6_cleanup_tunnel_devices
-
-		# Shut down generic tunnel interface now
-		if ipv6_test_device_status sit0 ; then
-			/sbin/ip link set sit0 down
-		fi
-		;;
-
-	    *)
-		echo "Usage: $0 $1 {pre|post}"
-		;;
-
-	esac
-	;;
+        # Set default route for autotunnel, if specified
+        if [ "$IPV6_DEFAULTDEV" = "sit0" -a "$IPV6_AUTOTUNNEL" = "yes" ]; then
+            if [ -n "$IPV6_DEFAULTGW" ]; then
+                ipv6_set_default_route $IPV6_DEFAULTGW $IPV6_DEFAULTDEV sit0
+            elif [ -n "$IPV6_DEFAULTDEV" ]; then
+                ipv6_set_default_route "" $IPV6_DEFAULTDEV sit0
+            fi
+        fi
+        ;;
 
     *)
-	echo $"Usage: $0 {start|stop|reload|restart|showsysctl}"
-	exit 1
-	;;
+        echo "Usage: $0 $1 {pre|post}"
+        ;;
+
+    esac
+    ;;
+
+stop)
+    case $POSITION in
+    pre)
+        ;;
+
+    post)
+        # IPv6 test, no module loaded, exit if system is not IPv6-ready
+        ipv6_test testonly || exit 0
+
+        if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
+            for i in /proc/sys/net/ipv6/conf/* ; do
+                interface=${i##*/}
+                sinterface=${interface/.//}
+                # Assume Host behaviour
+                /sbin/sysctl -e -w net.ipv6.conf.$sinterface.forwarding=0 >/dev/null 2>&1
+
+                # Disable autoconfiguration and redirects
+                /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_ra=0 >/dev/null 2>&1
+                /sbin/sysctl -e -w net.ipv6.conf.$sinterface.accept_redirects=0 >/dev/null 2>&1
+            done
+        fi
+
+        # Cleanup still existing tunnel devices
+        ipv6_cleanup_tunnel_devices
+
+        # Shut down generic tunnel interface now
+        if ipv6_test_device_status sit0 ; then
+            /sbin/ip link set sit0 down
+        fi
+        ;;
+
+    *)
+        echo "Usage: $0 $1 {pre|post}"
+        ;;
+
+    esac
+    ;;
+
+*)
+    echo $"Usage: $0 {start|stop|reload|restart|showsysctl}"
+    exit 1
+    ;;
 esac

--- a/sysconfig/network-scripts/network-functions-ipv6
+++ b/sysconfig/network-scripts/network-functions-ipv6
@@ -15,27 +15,27 @@
 # $1: (optional) testflag: currently supported: "testonly" (do not load a module)
 # return code: 0=ok 2=IPv6 test fails
 ipv6_test() {
-	local fn="ipv6_test"
+    local fn="ipv6_test"
 
-	local testflag=$1
+    local testflag=$1
 
-	if ! [ -f /proc/net/if_inet6 ]; then
-		if [ "$testflag" = "testonly" ]; then
-			return 2
-		else
-			modprobe ipv6
+    if ! [ -f /proc/net/if_inet6 ]; then
+        if [ "$testflag" = "testonly" ]; then
+            return 2
+        else
+            modprobe ipv6
 
-			if ! [ -f /proc/net/if_inet6 ]; then
-				return 2
-			fi
-		fi
-	fi
+            if ! [ -f /proc/net/if_inet6 ]; then
+                return 2
+            fi
+        fi
+    fi
 
-	if ! [ -d /proc/sys/net/ipv6/conf/ ]; then
-		return 2
-	fi
+    if ! [ -d /proc/sys/net/ipv6/conf/ ]; then
+        return 2
+    fi
 
-	return 0
+    return 0
 }
 
 ##### Static IPv6 route configuration
@@ -46,52 +46,52 @@ ipv6_test() {
 #  $3: [<Interface>] : (optional)
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem adding route
 ipv6_add_route() {
-	local fn="ipv6_add_route"
+    local fn="ipv6_add_route"
 
-	local networkipv6=$1
-	local gatewayipv6=$2
-	local device=$3		# maybe empty
+    local networkipv6=$1
+    local gatewayipv6=$2
+    local device=$3        # maybe empty
 
-	if [ -z "$networkipv6" ]; then
-		net_log $"Missing parameter 'IPv6-network' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$networkipv6" ]; then
+        net_log $"Missing parameter 'IPv6-network' (arg 1)" err $fn
+        return 1
+    fi
 
-	if [ -z "$gatewayipv6" ]; then
-		net_log $"Missing parameter 'IPv6-gateway' (arg 2)" err $fn
-		return 1
-	fi
+    if [ -z "$gatewayipv6" ]; then
+        net_log $"Missing parameter 'IPv6-gateway' (arg 2)" err $fn
+        return 1
+    fi
 
-	ipv6_test || return 2
+    ipv6_test || return 2
 
-	ipv6_test_ipv6_addr_valid $networkipv6 || return 2
-	ipv6_test_ipv6_addr_valid $gatewayipv6 || return 2
+    ipv6_test_ipv6_addr_valid $networkipv6 || return 2
+    ipv6_test_ipv6_addr_valid $gatewayipv6 || return 2
 
-	if [ -z "$device" ]; then
-		local returntxt="$(/sbin/ip -6 route add $networkipv6 via $gatewayipv6 metric 1 2>&1)"
-	else
-		if [ "$gatewayipv6" = "::" ]; then
-			local returntxt="$(/sbin/ip -6 route add $networkipv6 dev $device metric 1 2>&1)"
-		else
-			local returntxt="$(/sbin/ip -6 route add $networkipv6 via $gatewayipv6 dev $device metric 1 2>&1)"
-		fi
-	fi
+    if [ -z "$device" ]; then
+        local returntxt="$(/sbin/ip -6 route add $networkipv6 via $gatewayipv6 metric 1 2>&1)"
+    else
+        if [ "$gatewayipv6" = "::" ]; then
+            local returntxt="$(/sbin/ip -6 route add $networkipv6 dev $device metric 1 2>&1)"
+        else
+            local returntxt="$(/sbin/ip -6 route add $networkipv6 via $gatewayipv6 dev $device metric 1 2>&1)"
+        fi
+    fi
 
-	if [ -n "$returntxt" ]; then
-		if echo $returntxt | LC_ALL=C grep -q "File exists"; then
-			# Netlink: "File exists"
-			true
-		elif echo $returntxt | LC_ALL=C grep -q "No route to host"; then
-			# Netlink: "No route to host"
-			net_log $"'No route to host' adding route '$networkipv6' via gateway '$gatewayipv6' through device '$device'" err $fn
-			return 3
-		else
-			net_log $"Unknown error" err $fn
-			return 3
-		fi
-	fi
+    if [ -n "$returntxt" ]; then
+        if echo $returntxt | LC_ALL=C grep -q "File exists"; then
+            # Netlink: "File exists"
+            true
+        elif echo $returntxt | LC_ALL=C grep -q "No route to host"; then
+            # Netlink: "No route to host"
+            net_log $"'No route to host' adding route '$networkipv6' via gateway '$gatewayipv6' through device '$device'" err $fn
+            return 3
+        else
+            net_log $"Unknown error" err $fn
+            return 3
+        fi
+    fi
 
-	return 0
+    return 0
 }
 
 ##### automatic tunneling configuration
@@ -99,29 +99,29 @@ ipv6_add_route() {
 ## Configure automatic tunneling up
 # return code: 0=ok 2=IPv6 test fails 3=major problem
 ipv6_enable_autotunnel() {
-	local fn="ipv6_enable_autotunnel"
+    local fn="ipv6_enable_autotunnel"
 
-	ipv6_test || return 2
+    ipv6_test || return 2
 
-	# enable IPv6-over-IPv4 tunnels
-	if ipv6_test_device_status sit0; then
-		true
-	else
-		# bring up basic tunnel device
-		/sbin/ip link set sit0 up
+    # enable IPv6-over-IPv4 tunnels
+    if ipv6_test_device_status sit0; then
+        true
+    else
+        # bring up basic tunnel device
+        /sbin/ip link set sit0 up
 
-			if ! ipv6_test_device_status sit0; then
-				net_log $"Tunnel device 'sit0' enabling didn't work" err $fn
-				return 3
-			fi
+            if ! ipv6_test_device_status sit0; then
+                net_log $"Tunnel device 'sit0' enabling didn't work" err $fn
+                return 3
+            fi
 
-		# Set sysctls proper (regardless "default")
-		/sbin/sysctl -e -w net.ipv6.conf.sit0.forwarding=1 >/dev/null 2>&1
-		/sbin/sysctl -e -w net.ipv6.conf.sit0.accept_ra=0 >/dev/null 2>&1
-		/sbin/sysctl -e -w net.ipv6.conf.sit0.accept_redirects=0 >/dev/null 2>&1
-	fi
+        # Set sysctls proper (regardless "default")
+        /sbin/sysctl -e -w net.ipv6.conf.sit0.forwarding=1 >/dev/null 2>&1
+        /sbin/sysctl -e -w net.ipv6.conf.sit0.accept_ra=0 >/dev/null 2>&1
+        /sbin/sysctl -e -w net.ipv6.conf.sit0.accept_redirects=0 >/dev/null 2>&1
+    fi
 
-	return 0
+    return 0
 }
 
 ##### Interface configuration
@@ -131,63 +131,63 @@ ipv6_enable_autotunnel() {
 #  $2: <IPv6 address[/prefix]>
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_add_addr_on_device() {
-	local fn="ipv6_add_addr_on_device"
+    local fn="ipv6_add_addr_on_device"
 
-	local device=$1
-	local address=$2
+    local device=$1
+    local address=$2
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	if [ -z "$address" ]; then
-		net_log $"Missing parameter 'IPv6-address' (arg 2)" err $fn
-		return 1
-	fi
+    if [ -z "$address" ]; then
+        net_log $"Missing parameter 'IPv6-address' (arg 2)" err $fn
+        return 1
+    fi
 
-	ipv6_test || return 2
+    ipv6_test || return 2
 
-	ipv6_test_ipv6_addr_valid $address || return 1
+    ipv6_test_ipv6_addr_valid $address || return 1
 
-	ipv6_test_device_status $device
-	local result=$?
+    ipv6_test_device_status $device
+    local result=$?
 
-	if [ "$result" = "0" ]; then
-		true
-	elif [ "$result" != "11" ]; then
-		net_log $"Device '$device' doesn't exist" err $fn
-		return 3
-	else
-		/sbin/ip link set $device up
+    if [ "$result" = "0" ]; then
+        true
+    elif [ "$result" != "11" ]; then
+        net_log $"Device '$device' doesn't exist" err $fn
+        return 3
+    else
+        /sbin/ip link set $device up
 
-			if ! ipv6_test_device_status $device; then
-				net_log $"Device '$device' enabling didn't work" err $fn
-				return 3
-			fi
-	fi
+            if ! ipv6_test_device_status $device; then
+                net_log $"Device '$device' enabling didn't work" err $fn
+                return 3
+            fi
+    fi
 
-	# Extract address parts
-	local prefixlength_implicit="$(echo $address | awk -F/ '{ print $2 }')"
-	local address_implicit="${address%%/*}"
+    # Extract address parts
+    local prefixlength_implicit="$(echo $address | awk -F/ '{ print $2 }')"
+    local address_implicit="${address%%/*}"
 
-	# Check prefix length and using '64' as default
-	if [ -z "$prefixlength_implicit" ]; then
-		local prefixlength_implicit="64"
-		local address="$address_implicit/$prefixlength_implicit"
-	fi
+    # Check prefix length and using '64' as default
+    if [ -z "$prefixlength_implicit" ]; then
+        local prefixlength_implicit="64"
+        local address="$address_implicit/$prefixlength_implicit"
+    fi
 
-	/sbin/ip -6 addr add $address dev $device
-	local result=$?
+    /sbin/ip -6 addr add $address dev $device
+    local result=$?
 
-	if [ $result -eq 2 ]; then
-		return 0
-	elif [ $result -ne 0 ]; then
-		net_log $"Cannot add IPv6 address '$address' on dev '$device'" err $fn
-		return 3
-	fi
+    if [ $result -eq 2 ]; then
+        return 0
+    elif [ $result -ne 0 ]; then
+        net_log $"Cannot add IPv6 address '$address' on dev '$device'" err $fn
+        return 3
+    fi
 
-	return 0
+    return 0
 }
 
 
@@ -195,28 +195,28 @@ ipv6_add_addr_on_device() {
 #  $1: <Interface>
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_cleanup_device() {
-	local fn="ipv6_cleanup_device"
+    local fn="ipv6_cleanup_device"
 
-	local device=$1
+    local device=$1
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	# Remove all IPv6 routes through this device (but not "lo")
-	if [ "$device" != "lo" ]; then
-		/sbin/ip -6 route flush dev $device scope global >/dev/null 2>&1
-		/sbin/ip -6 route flush dev $device scope site   >/dev/null 2>&1
-	fi
+    # Remove all IPv6 routes through this device (but not "lo")
+    if [ "$device" != "lo" ]; then
+        /sbin/ip -6 route flush dev $device scope global >/dev/null 2>&1
+        /sbin/ip -6 route flush dev $device scope site     >/dev/null 2>&1
+    fi
 
-	# Remove all IPv6 addresses on this interface
-	/sbin/ip -6 addr flush dev $device scope global >/dev/null 2>&1
-	/sbin/ip -6 addr flush dev $device scope site   >/dev/null 2>&1
+    # Remove all IPv6 addresses on this interface
+    /sbin/ip -6 addr flush dev $device scope global >/dev/null 2>&1
+    /sbin/ip -6 addr flush dev $device scope site     >/dev/null 2>&1
 
-	return 0
+    return 0
 }
 
 
@@ -224,28 +224,28 @@ ipv6_cleanup_device() {
 #  $1: <Interface>
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_cleanup_6to4_device() {
-	local fn="ipv6_cleanup_6to4_device"
+    local fn="ipv6_cleanup_6to4_device"
 
-	local device=$1
+    local device=$1
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	# Cleanup 6to4 addresses on this device
-	/sbin/ip -6 addr show dev $dev scope global permanent | awk '/\<inet6\>/ && $2 ~ /^2002:/ { print $2 }' | while read addr; do
-		/sbin/ip -6 addr del ${addr} dev ${dev}
-	done
+    # Cleanup 6to4 addresses on this device
+    /sbin/ip -6 addr show dev $dev scope global permanent | awk '/\<inet6\>/ && $2 ~ /^2002:/ { print $2 }' | while read addr; do
+        /sbin/ip -6 addr del ${addr} dev ${dev}
+    done
 
-	# Get all IPv6 routes through given interface related to 6to4 and remove them
-	/sbin/ip -6 route show dev $device | LC_ALL=C grep "^2002:" | while read ipv6net dummy; do
-		/sbin/ip -6 route del $ipv6net dev $device
-	done
+    # Get all IPv6 routes through given interface related to 6to4 and remove them
+    /sbin/ip -6 route show dev $device | LC_ALL=C grep "^2002:" | while read ipv6net dummy; do
+        /sbin/ip -6 route del $ipv6net dev $device
+    done
 
-	return 0
+    return 0
 }
 
 
@@ -255,7 +255,7 @@ ipv6_cleanup_6to4_device() {
 #  $1: <IPv6 address>
 # return code: 0=ok 1=not valid
 ipv6_test_ipv6_addr_valid() {
-	ipcalc -cs6 $1
+    ipcalc -cs6 $1
 }
 
 
@@ -263,7 +263,7 @@ ipv6_test_ipv6_addr_valid() {
 #  $1: <IPv4 address>
 # return code: 0=ok 1=not valid
 ipv6_test_ipv4_addr_valid() {
-	ipcalc -cs4 $1
+    ipcalc -cs4 $1
 }
 
 
@@ -271,32 +271,32 @@ ipv6_test_ipv4_addr_valid() {
 #  $1: <IPv4 address>
 # return code: 0=ok 1=argument error 10=private or not unicast
 ipv6_test_ipv4_addr_global_usable() {
-	local fn="ipv6_test_ipv4_addr_global_usable"
+    local fn="ipv6_test_ipv4_addr_global_usable"
 
-	local testipv4addr_globalusable=$1
+    local testipv4addr_globalusable=$1
 
 
-	if [ -z "$testipv4addr_globalusable" ]; then
-		return 1
-	fi
+    if [ -z "$testipv4addr_globalusable" ]; then
+        return 1
+    fi
 
-	# Test for a globally usable IPv4 address now
-		# test 0.0.0.0/8
-		/bin/ipcalc --network $testipv4addr_globalusable 255.0.0.0   | LC_ALL=C grep -q "NETWORK=0\.0\.0\.0"     && return 10
-		# test 10.0.0.0/8     (RFC 1918 / private)
-		/bin/ipcalc --network $testipv4addr_globalusable 255.0.0.0   | LC_ALL=C grep -q "NETWORK=10\.0\.0\.0"    && return 10
-		# test 127.0.0.0/8    (loopback)
-		/bin/ipcalc --network $testipv4addr_globalusable 255.0.0.0   | LC_ALL=C grep -q "NETWORK=127\.0\.0\.0"   && return 10
-		# test 169.254.0.0/16 (APIPA / DHCP link local)
-		/bin/ipcalc --network $testipv4addr_globalusable 255.255.0.0 | LC_ALL=C grep -q "NETWORK=169\.254\.0\.0" && return 10
-		# test 172.16.0.0/12  (RFC 1918 / private)
-		/bin/ipcalc --network $testipv4addr_globalusable 255.240.0.0 | LC_ALL=C grep -q "NETWORK=172\.16\.0\.0"  && return 10
-		# test 192.168.0.0/16 (RFC 1918 / private)
-		/bin/ipcalc --network $testipv4addr_globalusable 255.255.0.0 | LC_ALL=C grep -q "NETWORK=192\.168\.0\.0" && return 10
-		# test 224.0.0.0/3    (multicast and reserved, broadcast)
-		/bin/ipcalc --network $testipv4addr_globalusable 224.0.0.0   | LC_ALL=C grep -q "NETWORK=224\.0\.0\.0"   && return 10
+    # Test for a globally usable IPv4 address now
+        # test 0.0.0.0/8
+        /bin/ipcalc --network $testipv4addr_globalusable 255.0.0.0     | LC_ALL=C grep -q "NETWORK=0\.0\.0\.0"         && return 10
+        # test 10.0.0.0/8         (RFC 1918 / private)
+        /bin/ipcalc --network $testipv4addr_globalusable 255.0.0.0     | LC_ALL=C grep -q "NETWORK=10\.0\.0\.0"        && return 10
+        # test 127.0.0.0/8        (loopback)
+        /bin/ipcalc --network $testipv4addr_globalusable 255.0.0.0     | LC_ALL=C grep -q "NETWORK=127\.0\.0\.0"     && return 10
+        # test 169.254.0.0/16 (APIPA / DHCP link local)
+        /bin/ipcalc --network $testipv4addr_globalusable 255.255.0.0 | LC_ALL=C grep -q "NETWORK=169\.254\.0\.0" && return 10
+        # test 172.16.0.0/12    (RFC 1918 / private)
+        /bin/ipcalc --network $testipv4addr_globalusable 255.240.0.0 | LC_ALL=C grep -q "NETWORK=172\.16\.0\.0"    && return 10
+        # test 192.168.0.0/16 (RFC 1918 / private)
+        /bin/ipcalc --network $testipv4addr_globalusable 255.255.0.0 | LC_ALL=C grep -q "NETWORK=192\.168\.0\.0" && return 10
+        # test 224.0.0.0/3        (multicast and reserved, broadcast)
+        /bin/ipcalc --network $testipv4addr_globalusable 224.0.0.0     | LC_ALL=C grep -q "NETWORK=224\.0\.0\.0"     && return 10
 
-	return 0
+    return 0
 }
 
 
@@ -304,29 +304,29 @@ ipv6_test_ipv4_addr_global_usable() {
 #  $1: <Interface>
 # return code: 0=ok 1=argument error 10=not exists 11=down
 ipv6_test_device_status() {
-	local fn="ipv6_test_device_status"
+    local fn="ipv6_test_device_status"
 
-	local device=$1
+    local device=$1
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	# Test if device exists
-	if [ ! -d "/sys/class/net/${device}" ]; then
-		# not exists
-		return 10
-	fi
+    # Test if device exists
+    if [ ! -d "/sys/class/net/${device}" ]; then
+        # not exists
+        return 10
+    fi
 
-	# Test if device is up
-	if /sbin/ip link show dev $device 2>/dev/null | LC_ALL=C grep -q "UP"; then
-		# up
-		return 0
-	else
-		# down
-		return 11
-	fi
+    # Test if device is up
+    if /sbin/ip link show dev $device 2>/dev/null | LC_ALL=C grep -q "UP"; then
+        # up
+        return 0
+    else
+        # down
+        return 11
+    fi
 }
 
 
@@ -335,38 +335,38 @@ ipv6_test_device_status() {
 # stdout: <6to4address>
 # return code: 0=ok 1=argument error
 ipv6_create_6to4_prefix() {
-	local fn="ipv6_create_6to4_prefix"
+    local fn="ipv6_create_6to4_prefix"
 
-	local ipv4addr=$1
+    local ipv4addr=$1
 
-	if [ -z "$ipv4addr" ]; then
-		net_log $"Missing parameter 'IPv4 address' (arg 1)" err $fn
-	fi
+    if [ -z "$ipv4addr" ]; then
+        net_log $"Missing parameter 'IPv4 address' (arg 1)" err $fn
+    fi
 
-	local major1="${ipv4addr%%.*}"
-	local minor1="$(echo $ipv4addr | awk -F. '{ print $2 }')"
-	local major2="$(echo $ipv4addr | awk -F. '{ print $3 }')"
-	local minor2="$(echo $ipv4addr | awk -F. '{ print $4 }')"
+    local major1="${ipv4addr%%.*}"
+    local minor1="$(echo $ipv4addr | awk -F. '{ print $2 }')"
+    local major2="$(echo $ipv4addr | awk -F. '{ print $3 }')"
+    local minor2="$(echo $ipv4addr | awk -F. '{ print $4 }')"
 
-	if [ -z "$major1" -o -z "$minor1" -o -z "$major2" -o -z "$minor2" ]; then
-		return 1
-	fi
+    if [ -z "$major1" -o -z "$minor1" -o -z "$major2" -o -z "$minor2" ]; then
+        return 1
+    fi
 
-	if [ $major1 -eq 0 ]; then
-		local block1="$(printf "%x" $minor1)"
-	else
-		local block1="$(printf "%x%02x" $major1 $minor1)"
-	fi
-	if [ $major2 -eq 0 ]; then
-		local block2="$(printf "%x" $minor2)"
-	else
-		local block2="$(printf "%x%02x" $major2 $minor2)"
-	fi
+    if [ $major1 -eq 0 ]; then
+        local block1="$(printf "%x" $minor1)"
+    else
+        local block1="$(printf "%x%02x" $major1 $minor1)"
+    fi
+    if [ $major2 -eq 0 ]; then
+        local block2="$(printf "%x" $minor2)"
+    else
+        local block2="$(printf "%x%02x" $major2 $minor2)"
+    fi
 
-	local prefix6to4="2002:$block1:$block2"
+    local prefix6to4="2002:$block1:$block2"
 
-	echo "$prefix6to4"
-	return 0
+    echo "$prefix6to4"
+    return 0
 }
 
 
@@ -375,33 +375,33 @@ ipv6_create_6to4_prefix() {
 # stdout: <tunnel relay address>
 # return code: 0=ok 1=argument error
 ipv6_create_6to4_relay_address() {
-	local fn="ipv6_create_6to4_relay_address"
+    local fn="ipv6_create_6to4_relay_address"
 
-	local addr=$1
+    local addr=$1
 
-	if [ -z "$addr" ]; then
-		net_log $"Missing parameter 'address' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$addr" ]; then
+        net_log $"Missing parameter 'address' (arg 1)" err $fn
+        return 1
+    fi
 
-	# Check
-	if ipv6_test_ipv4_addr_valid $addr ; then
-		# ok, a IPv4 one
-		if ipv6_test_ipv4_addr_global_usable $addr; then
-			# IPv4 globally usable
-			local ipv6to4_relay="::$addr"
-		else
-			net_log $"Given address '$addr' is not a global IPv4 one (arg 1)" err $fn
-			return 1
-		fi
-	else
-		net_log $"Given address '$addr' is not a valid IPv4 one (arg 1)" err $fn
-		return 1
-	fi
+    # Check
+    if ipv6_test_ipv4_addr_valid $addr ; then
+        # ok, a IPv4 one
+        if ipv6_test_ipv4_addr_global_usable $addr; then
+            # IPv4 globally usable
+            local ipv6to4_relay="::$addr"
+        else
+            net_log $"Given address '$addr' is not a global IPv4 one (arg 1)" err $fn
+            return 1
+        fi
+    else
+        net_log $"Given address '$addr' is not a valid IPv4 one (arg 1)" err $fn
+        return 1
+    fi
 
-	echo "$ipv6to4_relay"
+    echo "$ipv6to4_relay"
 
-	return 0
+    return 0
 }
 
 
@@ -415,65 +415,65 @@ ipv6_create_6to4_relay_address() {
 #  $5: [<IPv4 address>] : local IPv4 address of tunnel interface (required in case of 6to4 behind NAT)
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_add_6to4_tunnel() {
-	local fn="ipv6_add_6to4_tunnel"
+    local fn="ipv6_add_6to4_tunnel"
 
-	local device=$1
-	local globalipv4=$2
-	local globalipv6to4suffix=$3
-	local mtu=$4
-	local localipv4=$5
+    local device=$1
+    local globalipv4=$2
+    local globalipv6to4suffix=$3
+    local mtu=$4
+    local localipv4=$5
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	if [ -z "$globalipv4" ]; then
-		net_log $"Missing parameter 'global IPv4 address' (arg 2)" err $fn
-		return 1
-	fi
+    if [ -z "$globalipv4" ]; then
+        net_log $"Missing parameter 'global IPv4 address' (arg 2)" err $fn
+        return 1
+    fi
 
-	# Check device
-	if [ "$device" != "tun6to4" ]; then
-		net_log $"Given device '$device' is not supported (arg 1)" err $fn
-		return 1
-	fi
+    # Check device
+    if [ "$device" != "tun6to4" ]; then
+        net_log $"Given device '$device' is not supported (arg 1)" err $fn
+        return 1
+    fi
 
-	# Copy global IPv4 address to local if last one is not given
-	if [ -z "$localipv4" ]; then
-		localipv4="$globalipv4"
-	fi
+    # Copy global IPv4 address to local if last one is not given
+    if [ -z "$localipv4" ]; then
+        localipv4="$globalipv4"
+    fi
 
-	ipv6_test || return 2
+    ipv6_test || return 2
 
-	# Generate 6to4 address
-	local prefix6to4="$(ipv6_create_6to4_prefix $globalipv4)"
-	if [ $? -ne 0 -o -z "$prefix6to4" ]; then
-		return 3
-	fi
+    # Generate 6to4 address
+    local prefix6to4="$(ipv6_create_6to4_prefix $globalipv4)"
+    if [ $? -ne 0 -o -z "$prefix6to4" ]; then
+        return 3
+    fi
 
-	if [ -z "$globalipv6to4suffix" ]; then
-		local address6to4="${prefix6to4}::1/16"
-	else
-		local address6to4="${prefix6to4}::${globalipv6to4suffix}/16"
-	fi
+    if [ -z "$globalipv6to4suffix" ]; then
+        local address6to4="${prefix6to4}::1/16"
+    else
+        local address6to4="${prefix6to4}::${globalipv6to4suffix}/16"
+    fi
 
-		ipv6_add_tunnel_device tun6to4 0.0.0.0 $address6to4 $localipv4
-		if [ $? -ne 0 ]; then
-			local retval=3
-		else
-			local retval=0
-		fi
+        ipv6_add_tunnel_device tun6to4 0.0.0.0 $address6to4 $localipv4
+        if [ $? -ne 0 ]; then
+            local retval=3
+        else
+            local retval=0
+        fi
 
-		# Add unspecific unreachable route for local 6to4 address space
-		/sbin/ip route add unreach ${prefix6to4}::/48
+        # Add unspecific unreachable route for local 6to4 address space
+        /sbin/ip route add unreach ${prefix6to4}::/48
 
-	# Set MTU, if given
-	if [ -n "$mtu" ]; then
-		ipv6_set_mtu $device $mtu
-	fi
+    # Set MTU, if given
+    if [ -n "$mtu" ]; then
+        ipv6_set_mtu $device $mtu
+    fi
 
-	return $retval
+    return $retval
 }
 
 
@@ -481,31 +481,31 @@ ipv6_add_6to4_tunnel() {
 #  $1: <Interface> : only "tun6to4" is supported
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_cleanup_6to4_tunnels() {
-	local fn="ipv6_cleanup_6to4_tunnels"
+    local fn="ipv6_cleanup_6to4_tunnels"
 
-	local device=$1
+    local device=$1
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	# Check device
-	if [ "$device" != "tun6to4" ]; then
-		net_log $"Given device '$device' is not supported (arg 1)" err $fn
-		return 1
-	fi
+    # Check device
+    if [ "$device" != "tun6to4" ]; then
+        net_log $"Given device '$device' is not supported (arg 1)" err $fn
+        return 1
+    fi
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-		ipv6_del_tunnel_device tun6to4
+        ipv6_del_tunnel_device tun6to4
 
-		# Remove all unspecific unreachable routes for local 6to4 address space
-		/sbin/ip -6 route | LC_ALL=C grep "^unreachable 2002:.*/48 dev lo" | while read token net rest; do
-			/sbin/ip route del unreach $net
-		done
+        # Remove all unspecific unreachable routes for local 6to4 address space
+        /sbin/ip -6 route | LC_ALL=C grep "^unreachable 2002:.*/48 dev lo" | while read token net rest; do
+            /sbin/ip route del unreach $net
+        done
 
-	return 0
+    return 0
 }
 
 
@@ -514,36 +514,36 @@ ipv6_cleanup_6to4_tunnels() {
 #  $2: <IPv4 address> : global address of local interface
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_del_6to4_tunnel() {
-	local fn="ipv6_del_6to4_tunnel"
+    local fn="ipv6_del_6to4_tunnel"
 
-	local device=$1
-	local localipv4=$2
+    local device=$1
+    local localipv4=$2
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	if [ -z "$localipv4" ]; then
-		net_log $"Missing parameter 'local IPv4 address' (arg 2)" err $fn
-		return 1
-	fi
+    if [ -z "$localipv4" ]; then
+        net_log $"Missing parameter 'local IPv4 address' (arg 2)" err $fn
+        return 1
+    fi
 
-	# Check device
-	if [ "$device" != "tun6to4" ]; then
-		net_log $"Given device '$device' is not supported (arg 1)" err $fn
-		return 1
-	fi
+    # Check device
+    if [ "$device" != "tun6to4" ]; then
+        net_log $"Given device '$device' is not supported (arg 1)" err $fn
+        return 1
+    fi
 
-	ipv6_test || return 2
+    ipv6_test || return 2
 
-		ipv6_del_tunnel_device tun6to4
-		local retval=$?
+        ipv6_del_tunnel_device tun6to4
+        local retval=$?
 
-		# Remove unspecific unreachable route for local 6to4 address space
-		/sbin/ip route del unreach ${prefix6to4}::/48
+        # Remove unspecific unreachable route for local 6to4 address space
+        /sbin/ip route del unreach ${prefix6to4}::/48
 
-	return $retval
+    return $retval
 }
 
 
@@ -554,80 +554,80 @@ ipv6_del_6to4_tunnel() {
 #  $4: [<IPv4 address>] : local one of tunnel (optional)
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_add_tunnel_device() {
-	local fn="ipv6_add_tunnel_device"
+    local fn="ipv6_add_tunnel_device"
 
-	local device=$1
-	local addressipv4tunnel=$2
-	local addressipv6local=$3
-	local addressipv4tunnellocal=$4
+    local device=$1
+    local addressipv4tunnel=$2
+    local addressipv6local=$3
+    local addressipv4tunnellocal=$4
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	if [ -z "$addressipv4tunnel" ]; then
-		net_log $"Missing parameter 'IPv4-tunnel address' (arg 2)" err $fn
-		return 1
-	fi
+    if [ -z "$addressipv4tunnel" ]; then
+        net_log $"Missing parameter 'IPv4-tunnel address' (arg 2)" err $fn
+        return 1
+    fi
 
-	if [ -z "$addressipv4tunnellocal" ]; then
-		local addressipv4tunnellocal="any"
-	fi
+    if [ -z "$addressipv4tunnellocal" ]; then
+        local addressipv4tunnellocal="any"
+    fi
 
-	ipv6_test || return 2
+    ipv6_test || return 2
 
-	if ! ipv6_test_device_status $device; then
-		local ttldefault="$(/sbin/sysctl -e net.ipv4.ip_default_ttl | awk '{ print $3 }')"
-		if [ -z "$ttldefault" ]; then
-			local ttldefault=64
-		fi
+    if ! ipv6_test_device_status $device; then
+        local ttldefault="$(/sbin/sysctl -e net.ipv4.ip_default_ttl | awk '{ print $3 }')"
+        if [ -z "$ttldefault" ]; then
+            local ttldefault=64
+        fi
 
-		# Test whether remote IPv4 address was already applied to another tunnel
-		if [ "$addressipv4tunnel" != "0.0.0.0" -a "$addressipv4tunnel" != "any" ]; then
-			/sbin/ip tunnel show remote $addressipv4tunnel 2>/dev/null | LC_ALL=C grep -w "ipv6/ip" | while IFS=":" read devnew rest; do
-				if [ "$devnew" != "$device" ]; then
-					net_log $"Given remote address '$addressipv4tunnel' on tunnel device '$device' is already configured on device '$devnew'" err $fn
-					return 3
-				fi
-			done
-		fi
+        # Test whether remote IPv4 address was already applied to another tunnel
+        if [ "$addressipv4tunnel" != "0.0.0.0" -a "$addressipv4tunnel" != "any" ]; then
+            /sbin/ip tunnel show remote $addressipv4tunnel 2>/dev/null | LC_ALL=C grep -w "ipv6/ip" | while IFS=":" read devnew rest; do
+                if [ "$devnew" != "$device" ]; then
+                    net_log $"Given remote address '$addressipv4tunnel' on tunnel device '$device' is already configured on device '$devnew'" err $fn
+                    return 3
+                fi
+            done
+        fi
 
-		/sbin/ip tunnel add $device mode sit ttl $ttldefault remote $addressipv4tunnel local $addressipv4tunnellocal
-		if [ $? -ne 0 ]; then
-			return 3
-		fi
+        /sbin/ip tunnel add $device mode sit ttl $ttldefault remote $addressipv4tunnel local $addressipv4tunnellocal
+        if [ $? -ne 0 ]; then
+            return 3
+        fi
 
-		# Test, whether "ip tunnel show" reports valid content
-		if ! /sbin/ip tunnel show $device 2>/dev/null | LC_ALL=C grep -q -w "remote"; then
-			net_log $"Tunnel device '$device' creation didn't work" err $fn
-			return 3
-		fi
+        # Test, whether "ip tunnel show" reports valid content
+        if ! /sbin/ip tunnel show $device 2>/dev/null | LC_ALL=C grep -q -w "remote"; then
+            net_log $"Tunnel device '$device' creation didn't work" err $fn
+            return 3
+        fi
 
-		/sbin/ip link set $device up
+        /sbin/ip link set $device up
 
-		if ! ipv6_test_device_status $device; then
-			net_log $"Tunnel device '$device' bringing up didn't work" err $fn
-			return 3
-		fi
+        if ! ipv6_test_device_status $device; then
+            net_log $"Tunnel device '$device' bringing up didn't work" err $fn
+            return 3
+        fi
 
-		# Set sysctls proper (regardless "default")
-		/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=1 >/dev/null 2>&1
-		/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=0 >/dev/null 2>&1
-		/sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=0 >/dev/null 2>&1
+        # Set sysctls proper (regardless "default")
+        /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=1 >/dev/null 2>&1
+        /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=0 >/dev/null 2>&1
+        /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_redirects=0 >/dev/null 2>&1
 
-		if [ -n "$addressipv6local" ]; then
-			# Setup P-t-P address
-			ipv6_add_addr_on_device $device $addressipv6local
-			if [ $? -ne 0 ]; then
-				return 3
-			fi
-		fi
-	else
-		false
-	fi
+        if [ -n "$addressipv6local" ]; then
+            # Setup P-t-P address
+            ipv6_add_addr_on_device $device $addressipv6local
+            if [ $? -ne 0 ]; then
+                return 3
+            fi
+        fi
+    else
+        false
+    fi
 
-	return 0
+    return 0
 }
 
 
@@ -635,54 +635,54 @@ ipv6_add_tunnel_device() {
 #  $1: <Interface>
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_del_tunnel_device() {
-	local fn="ipv6_del_tunnel_device"
+    local fn="ipv6_del_tunnel_device"
 
-	local device=$1
+    local device=$1
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	if ipv6_test_device_status $device; then
-		ipv6_cleanup_device $device
-	else
-		if [ "$device" != "sit0" ]; then
-			false
-		fi
-	fi
+    if ipv6_test_device_status $device; then
+        ipv6_cleanup_device $device
+    else
+        if [ "$device" != "sit0" ]; then
+            false
+        fi
+    fi
 
-	if [ "$device" != "sit0" ]; then
-		if /sbin/ip tunnel show $device 2>/dev/null | LC_ALL=C grep -q -w "ipv6/ip"; then
-			/sbin/ip tunnel del $device
+    if [ "$device" != "sit0" ]; then
+        if /sbin/ip tunnel show $device 2>/dev/null | LC_ALL=C grep -q -w "ipv6/ip"; then
+            /sbin/ip tunnel del $device
 
-				if ipv6_test_device_status $device; then
-					return 3
-				fi
-		else
-			false
-		fi
-	fi
+            if ipv6_test_device_status $device; then
+                return 3
+            fi
+        else
+            false
+        fi
+    fi
 
-	return 0
+    return 0
 }
 
 
 ## Cleanup all dedicated tunnel devices
 ipv6_cleanup_tunnel_devices() {
-	local fn="ipv6_cleanup_tunnel_devices"
+    local fn="ipv6_cleanup_tunnel_devices"
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	# Find still existing tunnel devices and shutdown and delete them
+    # Find still existing tunnel devices and shutdown and delete them
 
-	/sbin/ip tunnel show | awk -F: '/\<ipv6\/ip\>/ { print $1 }' | while read device; do
-		ipv6_del_tunnel_device $device
-	done
+    /sbin/ip tunnel show | awk -F: '/\<ipv6\/ip\>/ { print $1 }' | while read device; do
+        ipv6_del_tunnel_device $device
+    done
 
-	return 0
+    return 0
 }
 
 
@@ -692,52 +692,52 @@ ipv6_cleanup_tunnel_devices() {
 # stdout: <IPv4 address> if available
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_get_ipv4addr_of_tunnel() {
-	local fn="ipv6_get_local_ipv4_of_tunnel"
+    local fn="ipv6_get_local_ipv4_of_tunnel"
 
-	local device=$1
-	local selection=$2
+    local device=$1
+    local selection=$2
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	if [ -z "$selection" ]; then
-		net_log $"Missing parameter 'selection' (arg 2)" err $fn
-		return 1
-	fi
-	if [ "$selection" != "local" -a "$selection" != "remote" ]; then
-		net_log $"Unsupported selection '$selection' specified (arg 2)" err $fn
-		return 1
-	fi
+    if [ -z "$selection" ]; then
+        net_log $"Missing parameter 'selection' (arg 2)" err $fn
+        return 1
+    fi
+    if [ "$selection" != "local" -a "$selection" != "remote" ]; then
+        net_log $"Unsupported selection '$selection' specified (arg 2)" err $fn
+        return 1
+    fi
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	ipv6_test_device_status $device
+    ipv6_test_device_status $device
 
-	if [ $? != 0 -a $? != 11 ]; then
-		# Device doesn't exist
-		return 3
-	fi
+    if [ $? != 0 -a $? != 11 ]; then
+        # Device doesn't exist
+        return 3
+    fi
 
-	# Device exists, retrieve address
-	if [ "$selection" = "local" ]; then
-		local tunnel_local_ipv4addr="$(/sbin/ip tunnel show $device | awk '{ print $6 }')"
-	elif [ "$selection" = "remote" ]; then
-		local tunnel_local_ipv4addr="$(/sbin/ip tunnel show $device | awk '{ print $4 }')"
-	fi
+    # Device exists, retrieve address
+    if [ "$selection" = "local" ]; then
+        local tunnel_local_ipv4addr="$(/sbin/ip tunnel show $device | awk '{ print $6 }')"
+    elif [ "$selection" = "remote" ]; then
+        local tunnel_local_ipv4addr="$(/sbin/ip tunnel show $device | awk '{ print $4 }')"
+    fi
 
-	if [ $? != 0 ]; then
-		return 3
-	fi
+    if [ $? != 0 ]; then
+        return 3
+    fi
 
-	if [ "$tunnel_local_ipv4addr" = "any" ]; then
-		local tunnel_local_ipv4addr="0.0.0.0"
-	fi
+    if [ "$tunnel_local_ipv4addr" = "any" ]; then
+        local tunnel_local_ipv4addr="0.0.0.0"
+    fi
 
-	echo "$tunnel_local_ipv4addr"
+    echo "$tunnel_local_ipv4addr"
 
-	return 0
+    return 0
 }
 
 
@@ -746,36 +746,36 @@ ipv6_get_ipv4addr_of_tunnel() {
 # stdout: <IPv4 address> if available
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem (more than one IPv4 address applied)
 ipv6_get_ipv4addr_of_device() {
-	local fn="ipv6_get_ipv4addr_of_device"
+    local fn="ipv6_get_ipv4addr_of_device"
 
-	local device=$1
+    local device=$1
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	ipv6_test_device_status $device
+    ipv6_test_device_status $device
 
-	if [ $? != 0 -a $? != 11 ]; then
-		# Device doesn't exist
-		return 3
-	fi
+    if [ $? != 0 -a $? != 11 ]; then
+        # Device doesn't exist
+        return 3
+    fi
 
-	# Device exists, retrieve the first address only
-	local ipv4addr="$(/sbin/ip -o -4 addr show dev $device | awk '{ print $4 }' | awk -F/ '{ print $1; exit }')"
+    # Device exists, retrieve the first address only
+    local ipv4addr="$(/sbin/ip -o -4 addr show dev $device | awk '{ print $4 }' | awk -F/ '{ print $1; exit }')"
 
-	if [ $? != 0 ]; then
-		return 3
-	fi
+    if [ $? != 0 ]; then
+        return 3
+    fi
 
-	if [ "$ipv4addr" = "any" ]; then
-		local ipv4addr="0.0.0.0"
-	fi
+    if [ "$ipv4addr" = "any" ]; then
+        local ipv4addr="0.0.0.0"
+    fi
 
-	echo "$ipv4addr"
+    echo "$ipv4addr"
 
-	return 0
+    return 0
 }
 
 
@@ -784,33 +784,33 @@ ipv6_get_ipv4addr_of_device() {
 #  $2: <IPv6 MTU>
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_set_mtu() {
-	local fn="ipv6_set_mtu"
+    local fn="ipv6_set_mtu"
 
-	local device=$1
-	local ipv6_mtu=$2
+    local device=$1
+    local ipv6_mtu=$2
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	if [ -z "$ipv6_mtu" ]; then
-		net_log $"Missing parameter 'IPv6 MTU' (arg 2)" err $fn
-		return 1
-	fi
+    if [ -z "$ipv6_mtu" ]; then
+        net_log $"Missing parameter 'IPv6 MTU' (arg 2)" err $fn
+        return 1
+    fi
 
-	# Check range
-	if [ $ipv6_mtu -lt 1280 -o $ipv6_mtu -gt 65535 ]; then
-		net_log $"Given IPv6 MTU '$ipv6_mtu' is out of range" err $fn
-		return 1
-	fi
+    # Check range
+    if [ $ipv6_mtu -lt 1280 -o $ipv6_mtu -gt 65535 ]; then
+        net_log $"Given IPv6 MTU '$ipv6_mtu' is out of range" err $fn
+        return 1
+    fi
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	# Set value
-	/sbin/ip link set dev $device mtu $ipv6_mtu
+    # Set value
+    /sbin/ip link set dev $device mtu $ipv6_mtu
 
-	return 0
+    return 0
 }
 
 
@@ -820,92 +820,92 @@ ipv6_set_mtu() {
 #  $3: <check device>: (optional) device to check scope and gateway device against (setup is skipped, if not matching)
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_set_default_route() {
-	local fn="ipv6_set_default_route"
+    local fn="ipv6_set_default_route"
 
-	local address=$1
-	local device=$2
-	local device_check=$3
+    local address=$1
+    local device=$2
+    local device_check=$3
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	# Map the unspecified address to nothing
-	if [ "$address" = "::" ]; then
-		local address=""
-	fi
+    # Map the unspecified address to nothing
+    if [ "$address" = "::" ]; then
+        local address=""
+    fi
 
-	if [ -n "$address" ]; then
-		local addressgw=${address%%%*}
-		local device_scope=$(echo $address | awk -F% '{ print $2 }')
+    if [ -n "$address" ]; then
+        local addressgw=${address%%%*}
+        local device_scope=$(echo $address | awk -F% '{ print $2 }')
 
-		if [ -z "$addressgw" ]; then
-			net_log $"Given IPv6 default gateway '$address' is not in proper format" err $fn
-			return 3
-		fi
+        if [ -z "$addressgw" ]; then
+            net_log $"Given IPv6 default gateway '$address' is not in proper format" err $fn
+            return 3
+        fi
 
-		# Scope device has precedence
-		if [ -n "$device_scope" -a -n "$device" -a "$device_scope" != "$device" ]; then
-			net_log $"Given IPv6 default gateway '$address' has scope '$device_scope' defined, given default gateway device '$device' will be not used" info $fn
-			local device=""
-		fi
+        # Scope device has precedence
+        if [ -n "$device_scope" -a -n "$device" -a "$device_scope" != "$device" ]; then
+            net_log $"Given IPv6 default gateway '$address' has scope '$device_scope' defined, given default gateway device '$device' will be not used" info $fn
+            local device=""
+        fi
 
-		# Link local addresses require a device
-		if echo $addressgw | LC_ALL=C grep -qi "^fe80:"; then
-			if [ -z "$device_scope" ]; then
-				if [ -z "$device" ]; then
-					net_log $"Given IPv6 default gateway '$address' is link-local, but no scope or gateway device is specified" err $fn
-					return 3
-				fi
-			fi
-		fi
+        # Link local addresses require a device
+        if echo $addressgw | LC_ALL=C grep -qi "^fe80:"; then
+            if [ -z "$device_scope" ]; then
+                if [ -z "$device" ]; then
+                    net_log $"Given IPv6 default gateway '$address' is link-local, but no scope or gateway device is specified" err $fn
+                    return 3
+                fi
+            fi
+        fi
 
-		# Check whether the route belongs to the specific given interface
-		if [ -n "$device_check" ]; then
-			# Check whether scope device matches given check device
-			if [ -n "$device_scope" -a "$device_check" != "$device_scope" ]; then
-				# scope device != specific given -> skip
-				return 0
-			elif [ -n "$device" -a "$device_check" != "$device" ]; then
-				# gateway device != specific given -> skip
-				return 0
-			fi
-		fi
+        # Check whether the route belongs to the specific given interface
+        if [ -n "$device_check" ]; then
+            # Check whether scope device matches given check device
+            if [ -n "$device_scope" -a "$device_check" != "$device_scope" ]; then
+                # scope device != specific given -> skip
+                return 0
+            elif [ -n "$device" -a "$device_check" != "$device" ]; then
+                # gateway device != specific given -> skip
+                return 0
+            fi
+        fi
 
-		# Set device now, if not given
-		if [ -z "$device" ]; then
-			local device="$device_scope"
-		fi
+        # Set device now, if not given
+        if [ -z "$device" ]; then
+            local device="$device_scope"
+        fi
 
-		if [ -z "$device" ]; then
-			# Note: this can cause a warning and a not installed route, if given address is not reachable on the link
-			ipv6_add_route ::/0 $addressgw
-		else
-			ipv6_add_route ::/0 $addressgw $device
-		fi
-	elif [ -n "$device" ]; then
-		# Check whether the route belongs to the specific given interface
-		if [ -n "$device_check" -a "$device_check" != "$device" ]; then
-			# gateway device != specific given -> skip
-			return 0
-		fi
+        if [ -z "$device" ]; then
+            # Note: this can cause a warning and a not installed route, if given address is not reachable on the link
+            ipv6_add_route ::/0 $addressgw
+        else
+            ipv6_add_route ::/0 $addressgw $device
+        fi
+    elif [ -n "$device" ]; then
+        # Check whether the route belongs to the specific given interface
+        if [ -n "$device_check" -a "$device_check" != "$device" ]; then
+            # gateway device != specific given -> skip
+            return 0
+        fi
 
-		ipv6_test_route_requires_next_hop $device
-		local result=$?
+        ipv6_test_route_requires_next_hop $device
+        local result=$?
 
-		if [ $result = 0 ]; then
-			net_log $"Given IPv6 default device '$device' requires an explicit nexthop" err $fn
-			return 3
-		elif [ $result != 10 ]; then
-			net_log $"Given IPv6 default device '$device' doesn't exist or isn't up" err $fn
-			return 3
-		fi
+        if [ $result = 0 ]; then
+            net_log $"Given IPv6 default device '$device' requires an explicit nexthop" err $fn
+            return 3
+        elif [ $result != 10 ]; then
+            net_log $"Given IPv6 default device '$device' doesn't exist or isn't up" err $fn
+            return 3
+        fi
 
-		ipv6_add_route ::/0 :: $device
-	else
-		net_log $"No parameters given to setup a default route" err $fn
-		return 3
-	fi
+        ipv6_add_route ::/0 :: $device
+    else
+        net_log $"No parameters given to setup a default route" err $fn
+        return 3
+    fi
 
-	return 0
+    return 0
 }
 
 
@@ -913,32 +913,32 @@ ipv6_set_default_route() {
 #  $1: <Interface>
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem 10=needs no explicit hop
 ipv6_test_route_requires_next_hop() {
-	local fn="ipv6_test_route_requires_next_hop"
+    local fn="ipv6_test_route_requires_next_hop"
 
-	local device=$1
+    local device=$1
 
-	if [ -z "$device" ]; then
-		net_log $"Missing parameter 'device' (arg 1)" err $fn
-		return 1
-	fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-	ipv6_test testonly || return 2
+    ipv6_test testonly || return 2
 
-	ipv6_test_device_status $device
+    ipv6_test_device_status $device
 
-	if [ $? != 0 ]; then
-		return 3
-	fi
+    if [ $? != 0 ]; then
+        return 3
+    fi
 
-	if [ "$device" = "sit0" ]; then
-		return 10
-	fi
+    if [ "$device" = "sit0" ]; then
+        return 10
+    fi
 
-	if /sbin/ip -o link show $device 2>/dev/null |  LC_ALL=C grep -q "POINTOPOINT"; then
-		return 10
-	fi
+    if /sbin/ip -o link show $device 2>/dev/null |    LC_ALL=C grep -q "POINTOPOINT"; then
+        return 10
+    fi
 
-	return 0
+    return 0
 }
 
 
@@ -946,120 +946,120 @@ ipv6_test_route_requires_next_hop() {
 #  $1: up|down : device reason for triggering (coming up or going down)
 #  $2: [startstop|restart|reload|SIGHUP] : triger mechanism (default is "SIGHUP")
 #        "startstop" : reason=up -> start, reason=down -> stop
-#  $3: [<filename>] : alternative pid file  [optional]
+#  $3: [<filename>] : alternative pid file    [optional]
 # return code: 0=ok 1=argument error 2=IPv6 test fails 3=major problem
 ipv6_trigger_radvd() {
-	local fn="ipv6_trigger_radvd"
+    local fn="ipv6_trigger_radvd"
 
-	local reason=$1
-	local mechanism=$2
-	local pidfile=$3
+    local reason=$1
+    local mechanism=$2
+    local pidfile=$3
 
-	if [ -z "$reason" ]; then
-		net_log $"No reason given for sending trigger to radvd" err $fn
-		return 1
-	fi
+    if [ -z "$reason" ]; then
+        net_log $"No reason given for sending trigger to radvd" err $fn
+        return 1
+    fi
 
-	if [ "$reason" != "up" -a "$reason" != "down" ]; then
-		net_log $"Unsupported reason '$reason' for sending trigger to radvd" err $fn
-		return 1
-	fi
+    if [ "$reason" != "up" -a "$reason" != "down" ]; then
+        net_log $"Unsupported reason '$reason' for sending trigger to radvd" err $fn
+        return 1
+    fi
 
-	if [ -z "$mechanism" ]; then
-		# Take default
-		local mechanism="SIGHUP"
-	fi
+    if [ -z "$mechanism" ]; then
+        # Take default
+        local mechanism="SIGHUP"
+    fi
 
-	if [ -z "$pidfile" ]; then
-		local pidfile="/var/run/radvd/radvd.pid"
-	fi
+    if [ -z "$pidfile" ]; then
+        local pidfile="/var/run/radvd/radvd.pid"
+    fi
 
-	# Print message and select action
-	case $mechanism in
-	    'startstop')
-		case $reason in
-		    up)
-			local action="start"
-			;;
-		    down)
-			local action="stop"
-			;;
-		esac
-		;;
-	    'reload'|'restart'|'SIGHUP')
-		local action="$mechanism"
-		;;
-	    *)
-		net_log $"Unsupported mechanism '$mechanism' for sending trigger to radvd" err $fn
-		return 3
-		;;
-	esac
+    # Print message and select action
+    case $mechanism in
+        'startstop')
+            case $reason in
+            up)
+                local action="start"
+                ;;
+            down)
+                local action="stop"
+                ;;
+            esac
+            ;;
+        'reload'|'restart'|'SIGHUP')
+            local action="$mechanism"
+            ;;
+        *)
+            net_log $"Unsupported mechanism '$mechanism' for sending trigger to radvd" err $fn
+            return 3
+            ;;
+    esac
 
-	# PID file needed?
-	if [ "$action" = "SIGHUP" ]; then
-		if ! [ -f "$pidfile" ]; then
-			if [ "$reason" = "down" ]; then
-				# be quiet because triggering may have been disabled
-				true
-			else
-				net_log $"Given pidfile '$pidfile' doesn't exist, cannot send trigger to radvd" err $fn
-			fi
-			return 3
-		fi
+    # PID file needed?
+    if [ "$action" = "SIGHUP" ]; then
+        if ! [ -f "$pidfile" ]; then
+            if [ "$reason" = "down" ]; then
+                # be quiet because triggering may have been disabled
+                true
+            else
+                net_log $"Given pidfile '$pidfile' doesn't exist, cannot send trigger to radvd" err $fn
+            fi
+            return 3
+        fi
 
-		# Get PID
-		local pid="$(cat $pidfile)"
-		if [ -z "$pid" ]; then
-			# pidfile empty - strange
-			net_log $"Pidfile '$pidfile' is empty, cannot send trigger to radvd" err $fn
-			return 3
-		fi
-	fi
+        # Get PID
+        local pid="$(cat $pidfile)"
+        if [ -z "$pid" ]; then
+            # pidfile empty - strange
+            net_log $"Pidfile '$pidfile' is empty, cannot send trigger to radvd" err $fn
+            return 3
+        fi
+    fi
 
 
-	# Do action
-	case $action in
-	    'SIGHUP')
-		kill -HUP $pid
-		;;
-	    'reload'|'restart'|'stop'|'start')
-			if ! /sbin/chkconfig --list radvd >/dev/null 2>&1; then
-				if [ "$reason" = "down" ]; then
-					# be quiet because triggering may have been disabled
-					true
-				else
-					net_log $"radvd not (properly) installed, triggering failed" err $fn
-				fi
-				return 3
-			else
-				/sbin/service radvd $action >/dev/null 2>&1
-			fi
-		;;
-	    *)
-		# Normally not reached, "action" is set above to proper value
-		;;
-	esac
+    # Do action
+    case $action in
+        'SIGHUP')
+            kill -HUP $pid
+            ;;
+        'reload'|'restart'|'stop'|'start')
+            if ! /sbin/chkconfig --list radvd >/dev/null 2>&1; then
+                if [ "$reason" = "down" ]; then
+                    # be quiet because triggering may have been disabled
+                    true
+                else
+                    net_log $"radvd not (properly) installed, triggering failed" err $fn
+                fi
+                return 3
+            else
+                /sbin/service radvd $action >/dev/null 2>&1
+            fi
+            ;;
+        *)
+            # Normally not reached, "action" is set above to proper value
+            ;;
+    esac
 
-	return 0
+    return 0
 }
 
 #https://www.vaspects.com/2013/12/11/services-dont-bind-to-ipv6-address/
 ipv6_wait_tentative() {
-        local fn="ipv6_wait_tentative"
-        local device=$1
-        local countdown=30
+    local fn="ipv6_wait_tentative"
+    local device=$1
+    local countdown=30
 
-        if [ -z "$device" ]; then
-                net_log $"Missing parameter 'device' (arg 1)" err $fn
-                return 1
-        fi
+    if [ -z "$device" ]; then
+        net_log $"Missing parameter 'device' (arg 1)" err $fn
+        return 1
+    fi
 
-        [ "$device" = lo ] && return 0
+    [ "$device" = lo ] && return 0
 
-        while [ ${countdown} -gt 0 -a -n "$(ip -6 addr show dev ${device} scope global tentative)" ]; do
-                net_log $"Waiting for interface ${device} IPv6 address(es) to leave the \"tentative\" state" info $fn
-                countdown=$(($countdown - 1))
-                sleep 1
-        done
-        return 0
+    while [ ${countdown} -gt 0 -a -n "$(ip -6 addr show dev ${device} scope global tentative)" ]; do
+        net_log $"Waiting for interface ${device} IPv6 address(es) to leave the \"tentative\" state" info $fn
+        countdown=$(($countdown - 1))
+        sleep 1
+    done
+    return 0
 }


### PR DESCRIPTION
The network-scripts are a mix of tabs and spaces (!!) as well as
completely inconsistent indentation (some 2, some 4).

This is a series of 3 patches to move the entire of network-scripts to
2-space indentation for consistency so I can develop on the codebase
without my brain bleeding. I don't feel strongly about 2 vs 4... 2 was
just most common in the first file I picked, so I used that.

This set is in 3 sets for easier reviewing and easier reverting if
necessary:

* 1/3 - ipv6 files
* 2/3 - network-functions - it needed it's own
* 3/3 - ifup/ifdown files