### PR TITLE
Support boolean values in is_true() & is_false() functions

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -603,7 +603,7 @@ is_ignored_file() {
 # Evaluate shvar-style booleans
 is_true() {
     case "$1" in
-    [tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE])
+    [tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE] | 1)
         return 0
         ;;
     esac
@@ -613,7 +613,7 @@ is_true() {
 # Evaluate shvar-style booleans
 is_false() {
     case "$1" in
-    [fF] | [nN] | [nN][oO] | [fF][aA][lL][sS][eE])
+    [fF] | [nN] | [nN][oO] | [fF][aA][lL][sS][eE] | 0)
         return 0
         ;;
     esac

--- a/sysconfig/network-scripts/ifdown-eth
+++ b/sysconfig/network-scripts/ifdown-eth
@@ -91,7 +91,7 @@ for VER in "" 6 ; do
     if [ -f "/var/run/dhclient$VER-${DEVICE}.pid" ]; then
         dhcpid=$(cat /var/run/dhclient$VER-${DEVICE}.pid)
         generate_lease_file_name $VER
-        if [[ "$DHCPRELEASE" = [yY1]* ]];  then
+        if is_true "$DHCPRELEASE";  then
             /sbin/dhclient -r -lf ${LEASEFILE} -pf /var/run/dhclient$VER-${DEVICE}.pid ${DEVICE} >/dev/null 2>&1
             retcode=$?
         else

--- a/sysconfig/network-scripts/ifup-aliases
+++ b/sysconfig/network-scripts/ifup-aliases
@@ -184,7 +184,7 @@ function new_interface ()
     fi
 
     if [ -z "$DEVICE" -o -z "$IPADDR" ]; then
-        if [ -n "$IPV6ADDR" -a -n "$DEVICE" ] && [[ "$IPV6INIT" != [nN0]* ]]; then
+        if [ -n "$IPV6ADDR" -a -n "$DEVICE" ] && ! is_false "$IPV6INIT"; then
             /etc/sysconfig/network-scripts/ifup-ipv6 ${DEVICE}
             return $?
         fi
@@ -277,7 +277,7 @@ function new_interface ()
         /sbin/ip addr add ${IPADDR}/${PREFIX} brd ${BROADCAST} \
             dev ${parent_device} label ${DEVICE}
 
-        [[ "$IPV6INIT" != [nN0]* ]] && \
+        ! is_false "$IPV6INIT" && \
             /etc/sysconfig/network-scripts/ifup-ipv6 ${DEVICE}
 
         if [ "$NO_ALIASROUTING" != yes ]; then

--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -178,7 +178,7 @@ if [ -n "${BRIDGE}" ] && [ -x /usr/sbin/brctl ]; then
 fi
 
 if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
-    if [[ "${PERSISTENT_DHCLIENT}" =  [yY1]* ]]; then
+    if is_true "${PERSISTENT_DHCLIENT}"; then
         ONESHOT="";
     else
         ONESHOT="-1";
@@ -188,7 +188,7 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
     DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
     echo
     echo -n $"Determining IP information for ${DEVICE}..."
-    if [[ "${PERSISTENT_DHCLIENT}" !=  [yY1]* ]] && check_link_down ${DEVICE}; then
+    if ! is_true "${PERSISTENT_DHCLIENT}" && check_link_down ${DEVICE}; then
         echo $" failed; no link present.  Check cable?"
         exit 1
     fi
@@ -200,10 +200,10 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
         dhcpipv4="good"
     else
         echo $" failed."
-        if [[ "${IPV4_FAILURE_FATAL}"  = [Yy1]* ]] ; then
+        if is_true "${IPV4_FAILURE_FATAL}"; then
             exit 1
         fi
-        if [[ "$IPV6INIT" = [nN0]* || "$DHCPV6C" != [yY1]* ]] ; then
+        if is_false "$IPV6INIT" || ! is_true "$DHCPV6C"; then
             exit 1
         fi
         net_log "Unable to obtain IPv4 DHCP address ${DEVICE}." warning
@@ -318,7 +318,7 @@ fi
 
 # IPv6 initialisation?
 /etc/sysconfig/network-scripts/ifup-ipv6 ${CONFIG}
-if [[ "${DHCPV6C}"  = [Yy1]* ]] && [ -x /sbin/dhclient ]; then
+if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
     generate_config_file_name 6
     generate_lease_file_name 6
     echo

--- a/sysconfig/network-scripts/ifup-ippp
+++ b/sysconfig/network-scripts/ifup-ippp
@@ -368,7 +368,7 @@ function addprovider()
     fi
 
     # Setup IPv6
-    if [[ "$IPV6INIT" != [nN0]* && ! -z "$IPV6ADDR" ]]; then
+    if ! is_false "$IPV6INIT" && ! [[ -z "$IPV6ADDR" ]]; then
         # Native IPv6 use of device configured, check of encapsulation required    
         if [ "$ENCAP" = "syncppp" ]; then
             echo $"Warning: ipppd (kernel 2.4.x and below) doesn't support IPv6 using encapsulation 'syncppp'"

--- a/sysconfig/network-scripts/ifup-ipv6
+++ b/sysconfig/network-scripts/ifup-ipv6
@@ -66,7 +66,7 @@ REALDEVICE=${DEVICE%%:*}
 DEVICE=$REALDEVICE
 
 # Test whether IPv6 configuration is disabled for this interface
-[[ "$IPV6INIT" = [nN0]* ]] && exit 0
+is_false "$IPV6INIT" && exit 0
 
 [ -f /etc/sysconfig/network-scripts/network-functions-ipv6 ] || exit 1
 . /etc/sysconfig/network-scripts/network-functions-ipv6

--- a/sysconfig/network-scripts/ifup-sit
+++ b/sysconfig/network-scripts/ifup-sit
@@ -44,7 +44,7 @@ REALDEVICE=${DEVICE%%:*}
 [ "$DEVICE" != "$REALDEVICE" ] && exit 0
 
 # Test whether IPv6 configuration is disabled for this interface
-[[ "$IPV6INIT" = [nN0]* ]] && exit 0
+is_false "$IPV6INIT" && exit 0
 
 [ -f /etc/sysconfig/network-scripts/network-functions-ipv6 ] || exit 1
 . /etc/sysconfig/network-scripts/network-functions-ipv6


### PR DESCRIPTION
`is_true()` now recognizes value `1` as `true`,
`is_false()` now recognizes value `0` as `false`.

And I replaced the `[yY1]*` and `[nN0]*` occurences with those functions where possible.