### PR TITLE
[RHEL6] ifup-aliases: do not fail when only IPv6 address is specified

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -786,7 +786,7 @@ is_ignored_file() {
 # Evaluate shvar-style booleans
 is_true() {
     case "$1" in
-	[tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE])
+	[tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE] | 1)
 	return 0
 	;;
     esac
@@ -796,7 +796,7 @@ is_true() {
 # Evaluate shvar-style booleans
 is_false() {
     case "$1" in
-	[fF] | [nN] | [nN][oO] | [fF][aA][lL][sS][eE])
+	[fF] | [nN] | [nN][oO] | [fF][aA][lL][sS][eE] | 0)
 	return 0
 	;;
     esac

--- a/sysconfig/network-scripts/ifup-aliases
+++ b/sysconfig/network-scripts/ifup-aliases
@@ -134,6 +134,7 @@ function ini_env ()
 {
        DEVICE=""
        IPADDR=""
+       IPV6ADDR=""
        PREFIX=$default_PREFIX
        NETMASK=$default_NETMASK
        BROADCAST=$default_BROADCAST
@@ -184,6 +185,10 @@ function new_interface ()
        fi
 
        if [ -z "$DEVICE" -o -z "$IPADDR" ]; then
+              if [ -n "$IPV6ADDR" -a -n "$DEVICE" ] && is_true "$IPV6INIT"; then
+                    /etc/sysconfig/network-scripts/ifup-ipv6 ${DEVICE}
+                    return $?
+              fi
               net_log $"error in $FILE: didn't specify device or ipaddr"
 	      return 1
        fi


### PR DESCRIPTION
Resolves RHBZ [#1340169](https://bugzilla.redhat.com/show_bug.cgi?id=1340169).