### PR TITLE
Fix for 6to4 bug

### DIFF
--- a/sysconfig/network-scripts/network-functions-ipv6
+++ b/sysconfig/network-scripts/network-functions-ipv6
@@ -236,8 +236,8 @@ ipv6_cleanup_6to4_device() {
     ipv6_test testonly || return 2
 
     # Cleanup 6to4 addresses on this device
-    /sbin/ip -6 addr show dev $dev scope global permanent | awk '/\<inet6\>/ && $2 ~ /^2002:/ { print $2 }' | while read addr; do
-        /sbin/ip -6 addr del ${addr} dev ${dev}
+    /sbin/ip -6 addr show dev $device scope global permanent | awk '/\<inet6\>/ && $2 ~ /^2002:/ { print $2 }' | while read addr; do
+        /sbin/ip -6 addr del ${addr} dev ${device}
     done
 
     # Get all IPv6 routes through given interface related to 6to4 and remove them


### PR DESCRIPTION
the diffs here are gonna be insane until the other PRs are merged, but the read diff is:

```
$ git show
commit 98f25d7807dee7a222f12476a0dd081f23703da3
Author: Phil Dibowitz <phil@ipom.com>
Date:   54 seconds ago

    Fix typo'd variable in 6to4 cleanup
    
    Thanks to shellcheck. :)
    
    This is ontop of the whitespace PRs, those should go in first.

diff --git a/sysconfig/network-scripts/network-functions-ipv6 b/sysconfig/network-scripts/network-functions-ipv6
index 6ff6a76..2017e27 100644
--- a/sysconfig/network-scripts/network-functions-ipv6
+++ b/sysconfig/network-scripts/network-functions-ipv6
@@ -236,8 +236,8 @@ ipv6_cleanup_6to4_device() {
     ipv6_test testonly || return 2
 
     # Cleanup 6to4 addresses on this device
-    /sbin/ip -6 addr show dev $dev scope global permanent | awk '/\<inet6\>/ && $2 ~ /^2002:/ { print $2 }' | while read addr; do
-        /sbin/ip -6 addr del ${addr} dev ${dev}
+    /sbin/ip -6 addr show dev $device scope global permanent | awk '/\<inet6\>/ && $2 ~ /^2002:/ { print $2 }' | while read addr; do
+        /sbin/ip -6 addr del ${addr} dev ${device}
     done
 
     # Get all IPv6 routes through given interface related to 6to4 and remove them
```