### PR TITLE
service: avoid double spaces in systemctl commands

### DIFF
--- a/service
+++ b/service
@@ -83,7 +83,7 @@ elif [ -x "${ACTIONDIR}/${SERVICE}/${ACTION}" -a -n "${ACTION}" ]; then
    env -i PATH="$PATH" TERM="$TERM" SYSTEMCTL_IGNORE_DEPENDENCIES=${SYSTEMCTL_IGNORE_DEPENDENCIES} SYSTEMCTL_SKIP_REDIRECT=${SYSTEMCTL_SKIP_REDIRECT} "${ACTIONDIR}/${SERVICE}/${ACTION}" ${OPTIONS}
 elif `echo $ACTION | egrep -qw "start|stop|restart|try-restart|reload|force-reload|status|condrestart"` ; then
    SERVICE_MANGLED=$(/usr/bin/systemd-escape --mangle ${SERVICE})
-   echo $"Redirecting to /bin/systemctl ${ACTION} ${OPTIONS} ${SERVICE_MANGLED}" >&2
+   echo $"Redirecting to /bin/systemctl ${ACTION}${OPTIONS:+ }${OPTIONS} ${SERVICE_MANGLED}" >&2
    exec /bin/systemctl ${ACTION} ${OPTIONS} ${SERVICE_MANGLED}
 else
    echo $"The service command supports only basic LSB actions (start, stop, restart, try-restart, reload, force-reload, status). For other actions, please try to use systemctl." >&2


### PR DESCRIPTION
When running:

```
service x restart
```

You get:

```
Redirecting to /bin/systemctl restart  x.service
```

With 2 spaces after restart.

This commits fixes that behaviour.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>