### PR TITLE
Add ability to specify arbitrary route options

### DIFF
--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -284,11 +284,13 @@ else
             # set up default gateway. replace if one already exists
             if [ -n "${GATEWAY}" ] && [ "$(ipcalc --network ${GATEWAY} ${netmask[0]} 2>/dev/null)" = "NETWORK=${NETWORK}" ]; then
                 ip route replace default ${METRIC:+metric $METRIC} \
+                    ${EXTRA_ROUTE_OPTS} \
                     via ${GATEWAY} ${WINDOW:+window $WINDOW} ${SRC} \
                     ${GATEWAYDEV:+dev $GATEWAYDEV} ||
                     net_log $"Error adding default gateway ${GATEWAY} for ${DEVICE}."
             elif [ "${GATEWAYDEV}" = "${DEVICE}" ]; then
                 ip route replace default ${METRIC:+metric $METRIC} \
+                    ${EXTRA_ROUTE_OPTS} \
                     ${SRC} ${WINDOW:+window $WINDOW} dev ${REALDEVICE} ||
                     net_log $"Error adding default gateway for ${REALDEVICE}."
             fi


### PR DESCRIPTION
`ifup` can set _some_ route options. Today it's missing several and so, to set
something like `mtu` or `advmss` you have to do hacks like:

```
METRIC='10 mtu 1480'
```

which is sub-optimal. Rather than one-off add support for everything in the man
page, provide a hook for arbitrary extra route options.