### PR TITLE
netconsole: resolve domain name via 'getent' instead of 'hosts'

### DIFF
--- a/rc.d/init.d/netconsole
+++ b/rc.d/init.d/netconsole
@@ -67,9 +67,26 @@ start ()
 	SYSLOGOPTS=
 	# syslogd server, if any
 	if [ -n "$SYSLOGADDR" ]; then
-		MATCH="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
-		if ! [[ "$SYSLOGADDR" =~ $MATCH ]]; then
-			SYSLOGADDR=$(LANG=C host $SYSLOGADDR 2>/dev/null | awk '/has address / { print $NF }')
+		# IPv6 regex also covers 4to6, zero-compressed, and link-local addresses with zone-index addresses.
+		# It should also cover IPv4-embedded, IPv4-mapped, and IPv4-translated IPv6 addresses.
+		# Taken from: http://stackoverflow.com/a/17871737/3481531
+		IPv4_regex="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
+		IPv6_regex="^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$"
+		if ! [[ "$SYSLOGADDR" =~ $IPv4_regex ]] && ! [[ "$SYSLOGADDR" =~ $IPv6_regex ]]; then
+			# Use IPv4 by default:
+			SYSLOGADDR="$(LANG=C getent ahostsv4 $SYSLOGADDR 2> /dev/null)"
+
+			# Try IPv6 in case IPv4 resolution has failed:
+			if [[ $? -eq 2 ]]; then
+				SYSLOGADDR="$(LANG=C getent ahostsv6 $SYSLOGADDR 2> /dev/null)"
+			fi
+
+			if [[ $? -ne 0 ]]; then
+				echo $"Unable to resolve IP address specified in /etc/sysconfig/netconsole" 1>&2
+				exit 6
+			fi
+
+			SYSLOGADDR="$(echo "$SYSLOGADDR" | head -1 | cut --delimiter=' ' --fields=1)"
 		fi
 	fi
 	if [ -z "$SYSLOGADDR" ] ; then


### PR DESCRIPTION
This commit solves the issue described in [RHBZ #1278519](https://bugzilla.redhat.com/show_bug.cgi?id=1278519).

When the nameserver address lines are not present in `/etc/resolv.conf`, launching
`/etc/init.d/netconsole start` will result in this error:

``` shell
Server address not specified in /etc/sysconfig/netconsole
```

This was caused by using `hosts` command for domain name resolution. This is now
fixed by using `getent` command instead.

I have improved the patch provided in the RHBZ, here is the basic overview:
- To test if the `IPV6INIT` variable is set to `yes`, we are now using `is_true`
  instead of grep-ing the value from `/etc/sysconfig/network` directly.
- Testing of initially set `$SYSLOGADDR` with regular expressions has been extended.
  The regex for IPv6 has been added, and it is unfortunately quite huge because of possible
  IPv6 variations (e.g. 4to6). It was taken from [Stack Overflow](http://stackoverflow.com/a/17871737/3481531) and
  edited. (It does not accept the mask of IP address - e.g. /64 ). The regex has been tested via [regexpal.com](http://www.regexpal.com/93988).
  (You can test it yourself -- copy-paste the regex there.)
- In case no IP address is specified in `$SYSLOGADDR`, then we assume the domain name is used and try to resolve it. The default behaviour for
  this depends on if `IPV6INIT` is set, and other conditions. Excerpt from the patch:

``` shell
The address resolution will follow up this scheme:
0) Is the use of IPv6 forced (by 'IPV6INIT=yes' in /etc/sysconfig/network)?
   If yes ->> use IPv6
1) If only IPv4 is available ->> use IPv4
2) If only IPv6 is available ->> use IPv6
3) If both IPv4 and IPv6 are available ->> use IPv4 by default
```

This should remain same for both RHEL6 and RHEL7/Fedora. I know that IPv6 is disabled on RHEL6, by default, and enabled in RHEL7/Fedora by default, but that is a separate (orthogonal) thing.  When IPv6 is not forced, and both IPv4 and IPv6 are specified for the same domain name, the script will fallback to use of IPv4, which IMHO is desirable. IOW, the script is not forcing IPv6 on user unless there's no other IP available for that specific domain name.

I have successfully tested the patch on RHEL-6.8.
