### PR TITLE
netconsole: resolve domain name via 'getent' instead of 'hosts'

### DIFF
--- a/rc.d/init.d/netconsole
+++ b/rc.d/init.d/netconsole
@@ -67,9 +67,26 @@ start ()
 	SYSLOGOPTS=
 	# syslogd server, if any
 	if [ -n "$SYSLOGADDR" ]; then
-		MATCH="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
-		if ! [[ "$SYSLOGADDR" =~ $MATCH ]]; then
-			SYSLOGADDR=$(LANG=C host $SYSLOGADDR 2>/dev/null | awk '/has address / { print $NF }')
+		# IPv6 regex also covers 4to6, zero-compressed, and link-local addresses with zone-index addresses.
+		# It should also cover IPv4-embedded, IPv4-mapped, and IPv4-translated IPv6 addresses.
+		# Taken from: http://stackoverflow.com/a/17871737/3481531
+		IPv4_regex="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
+		IPv6_regex="^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$"
+		if ! [[ "$SYSLOGADDR" =~ $IPv4_regex ]] && ! [[ "$SYSLOGADDR" =~ $IPv6_regex ]]; then
+			# Use IPv4 by default:
+			SYSLOGADDR="$(LANG=C getent ahostsv4 $SYSLOGADDR 2> /dev/null)"
+
+			# Try IPv6 in case IPv4 resolution has failed:
+			if [[ $? -eq 2 ]]; then
+				SYSLOGADDR="$(LANG=C getent ahostsv6 $SYSLOGADDR 2> /dev/null)"
+			fi
+
+			if [[ $? -ne 0 ]]; then
+				echo $"Unable to resolve IP address specified in /etc/sysconfig/netconsole" 1>&2
+				exit 6
+			fi
+
+			SYSLOGADDR="$(echo "$SYSLOGADDR" | head -1 | cut --delimiter=' ' --fields=1)"
 		fi
 	fi
 	if [ -z "$SYSLOGADDR" ] ; then


### PR DESCRIPTION
Adding this fix into RHEL6. For more info, see pull request #18.
