### PR TITLE
ifup-aliases: don't return with error when arping fails

### DIFF
--- a/sysconfig/network-scripts/ifup-aliases
+++ b/sysconfig/network-scripts/ifup-aliases
@@ -268,12 +268,15 @@ function new_interface ()
                is_available ${parent_device} && \
                ( grep -qswi "up" /sys/class/net/${parent_device}/operstate ||  grep -qswi "1" /sys/class/net/${parent_device}/carrier ) ; then
                    echo $"Determining if ip address ${IPADDR} is already in use for device ${parent_device}..."
-                   if ! ARPING=$(/sbin/arping -c 2 -w ${ARPING_WAIT:-3} -D -I ${parent_device} ${IPADDR}) ; then
-                                           ARPINGMAC=$(echo $ARPING |  sed -ne 's/.*\[\(.*\)\].*/\1/p')
-                                           net_log $"Error, some other host ($ARPINGMAC) already uses address ${IPADDR}."
-					   return 1
-				   fi
-			   fi
+
+                    ARPING="/sbin/arping -q -c 2 -w ${ARPING_WAIT:-3} -D -I ${parent_device} ${IPADDR}"
+
+                    if [ $? = 1 ]; then
+                        ARPINGMAC=$(echo $ARPING |  sed -ne 's/.*\[\(.*\)\].*/\1/p')
+                        net_log $"Error, some other host ($ARPINGMAC) already uses address ${IPADDR}."
+                        return 1
+                    fi
+               fi
 
                /sbin/ip addr add ${IPADDR}/${PREFIX} brd ${BROADCAST} dev ${parent_device} label ${DEVICE}
 


### PR DESCRIPTION
This is a backport of commit 55a50ebc591ebd0f4cfbb8ecc204fa20ee6a7368 to RHEL6, as sugested by Jan Scotka in [RHBZ #1275550](https://bugzilla.redhat.com/show_bug.cgi?id=1275550).
