### PR TITLE
ifup: do not delegate bridges/bonds/vlans to NetworkManager by default

### DIFF
--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -171,6 +171,19 @@ source_config ()
     else
         ISALIAS=no
     fi
+
+    if ! is_true "$NM_BOND_BRIDGE_VLAN_ENABLED"; then
+        case "$TYPE" in
+            Bridge | Bond | Vlan)
+                NM_CONTROLLED=no
+                ;;
+        esac
+    fi
+
+    if [[ "$TYPE" == "Infiniband" && -n "$PHYSDEV" ]]; then
+        NM_CONTROLLED=no
+    fi
+
     if is_nm_running && [ "$REALDEVICE" != "lo" ] ; then
         nmcli con load "/etc/sysconfig/network-scripts/$CONFIG"
         if ! is_false $NM_CONTROLLED; then


### PR DESCRIPTION
This pull-request solves the issue when the VLANs are managed by NetworkManager,
they can't be brought up. This is a modified patch, originally written by Lubomir Rintel.

Additionally, the Infiniband partitions are ignored as well.

This issue was originally reported in [RHBZ #1284115](https://bugzilla.redhat.com/show_bug.cgi?id=1284115).
