### PR TITLE
ifup-aliases: send gratuitous ARPs when adding addresses

### DIFF
--- a/sysconfig/network-scripts/ifup-aliases
+++ b/sysconfig/network-scripts/ifup-aliases
@@ -277,6 +277,12 @@ function new_interface ()
         /sbin/ip addr add ${IPADDR}/${PREFIX} brd ${BROADCAST} \
             dev ${parent_device} label ${DEVICE}
 
+        # update ARP cache of neighboring computers:
+        if [ "${REALDEVICE}" != "lo" ]; then
+            /sbin/arping -q -A -c 1 -I ${parent_device} ${IPADDR}
+            ( sleep 2; /sbin/arping -q -U -c 1 -I ${parent_device} ${IPADDR} ) > /dev/null 2>&1 < /dev/null &
+        fi
+
         ! is_false "$IPV6INIT" && \
             /etc/sysconfig/network-scripts/ifup-ipv6 ${DEVICE}
 


### PR DESCRIPTION
Excerpt from [RHBZ #1320366](https://bugzilla.redhat.com/show_bug.cgi?id=1320366):

_`ifup-aliases` does not send gratuitous ARP updates when adding addresses.
When moving one or more aliases from one server to another, those IPs may not be
reachable for some time (depending on the ARP timeout on the upstream router)._
