### PR TITLE
ifup-aliases: don't return with error when arping fails

### DIFF
--- a/sysconfig/network-scripts/ifup-aliases
+++ b/sysconfig/network-scripts/ifup-aliases
@@ -268,9 +268,9 @@ function new_interface ()
                is_available ${parent_device} && \
                ( grep -qswi "up" /sys/class/net/${parent_device}/operstate ||  grep -qswi "1" /sys/class/net/${parent_device}/carrier ) ; then
                    echo $"Determining if ip address ${IPADDR} is already in use for device ${parent_device}..."
-                   if ! ARPING=$(/sbin/arping -c 2 -w ${ARPING_WAIT:-3} -D -I ${parent_device} ${IPADDR}) ; then
-                                           ARPINGMAC=$(echo $ARPING |  sed -ne 's/.*\[\(.*\)\].*/\1/p')
-                                           net_log $"Error, some other host ($ARPINGMAC) already uses address ${IPADDR}."
+				   /sbin/arping -q -c 2 -w ${ARPING_WAIT:-3} -D -I ${parent_device} ${IPADDR}
+				   if [ $? = 1 ]; then
+					   net_log $"Error, some other host already uses address ${IPADDR}."
 					   return 1
 				   fi
 			   fi


### PR DESCRIPTION
Backport of commit 55a50ebc591ebd0f4cfbb8ecc2, to resolve [RHBZ #1333544](https://bugzilla.redhat.com/show_bug.cgi?id=1333544).