### PR TITLE
Revert of "ifup-aliases: do not fail when only ipv6 addr is specified"

### DIFF
--- a/sysconfig/network-scripts/ifup-aliases
+++ b/sysconfig/network-scripts/ifup-aliases
@@ -134,7 +134,6 @@ function ini_env ()
 {
        DEVICE=""
        IPADDR=""
-       IPV6ADDR=""
        PREFIX=$default_PREFIX
        NETMASK=$default_NETMASK
        BROADCAST=$default_BROADCAST
@@ -185,10 +184,6 @@ function new_interface ()
        fi
 
        if [ -z "$DEVICE" -o -z "$IPADDR" ]; then
-              if [ -n "$IPV6ADDR" -a -n "$DEVICE" ] && is_true "$IPV6INIT"; then
-                    /etc/sysconfig/network-scripts/ifup-ipv6 ${DEVICE}
-                    return $?
-              fi
               net_log $"error in $FILE: didn't specify device or ipaddr"
 	      return 1
        fi


### PR DESCRIPTION
This reverts commit 1cd4606a6de43fb9914f7099db2e30e3e2932dc0.
  For more info see [RHBZ #1340169](https://bugzilla.redhat.com/show_bug.cgi?id=1340169#c8).