### PR TITLE
init/kexec-disable.conf: release kexec memory properly

### DIFF
--- a/init/kexec-disable.conf
+++ b/init/kexec-disable.conf
@@ -8,7 +8,7 @@ task
 
 script
 	if [ ! -x /sbin/kexec ] || ! chkconfig kdump 2>/dev/null ; then
-		grep -q "crashkernel=auto" /proc/cmdline && \
+		dmesg | grep --silent --max-count=1 -e '^Command line:.*crashkernel=auto' && \
 		echo -n "0" > /sys/kernel/kexec_crash_size 2>/dev/null
 	fi
 	exit 0


### PR DESCRIPTION
Previously, the kexec memory was freed everytime. After patch from [RHBZ #734987](https://bugzilla.redhat.com/show_bug.cgi?id=734987),
it does not free the kexec memory at all.

This patch fixes this regression (resolves [RHBZ #1378198](https://bugzilla.redhat.com/show_bug.cgi?id=1378198)).