### PR TITLE
ipcalc: detect invalid mask

### DIFF
--- a/src/ipcalc.c
+++ b/src/ipcalc.c
@@ -107,6 +107,8 @@ int mask2prefix(struct in_addr mask)
     uint32_t saddr = ntohl(mask.s_addr);
 
     for (count=0; saddr > 0; count++) {
+        if (!((1 << 31) & saddr))
+                return -1;
         saddr=saddr << 1;
     }
 
@@ -339,6 +341,11 @@ int main(int argc, const char **argv) {
                 return 1;
             }
             prefix = mask2prefix(netmask);
+            if (prefix < 0 ) {
+                if (!beSilent)
+                    fprintf(stderr, "ipcalc: bad netmask: %s\n", netmaskStr);
+                return 1;
+            }
         }
     }
 


### PR DESCRIPTION
Backport of commit ee0eb388018636443799a9fa88eee47c86ab1565 into RHEL-6.9. Resolves [RHBZ #1377986](https://bugzilla.redhat.com/show_bug.cgi?id=1377986).