### PR TITLE
network-functions: do not send hostname via dhclient everytime

### DIFF
--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -185,7 +185,13 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
     fi;
     generate_config_file_name
     generate_lease_file_name
-    DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+
+    if need_hostname; then
+        DHCLIENTARGS="${DHCLIENTARGS} ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    else
+        DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    fi
+
     echo
     echo -n $"Determining IP information for ${DEVICE}..."
     if ! is_true "${PERSISTENT_DHCLIENT}" && check_link_down ${DEVICE}; then
@@ -326,7 +332,14 @@ if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
     generate_lease_file_name 6
     echo
     echo -n $"Determining IPv6 information for ${DEVICE}..."
-    if /sbin/dhclient -6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE} ; then
+
+    if need_hostname; then
+        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
+    else
+        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE}"
+    fi
+
+    if /sbin/dhclient "$DHCLIENTARGS"; then
         echo $" done."
     else
         echo $" failed."

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -355,13 +355,16 @@ is_available_wait ()
 
 need_hostname ()
 {
-    CHECK_HOSTNAME=$(hostname)
-    if [ "$CHECK_HOSTNAME" = "(none)" -o "$CHECK_HOSTNAME" = "localhost" -o \
-             "$CHECK_HOSTNAME" = "localhost.localdomain" ]; then
-        return 0
-    else
-        return 1
-    fi
+    CHECK_HOSTNAME="$(hostname)"
+
+    case "$CHECK_HOSTNAME" in
+        '(none)' | 'localhost' | 'localhost.localdomain')
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 set_hostname ()


### PR DESCRIPTION
The commit cd475bf315b9c08e9f1732c0b9de95729025d1c5 introduced a regression where dhclient is now sending the current hostname (the `-H` option) everytime when `ifup-eth` is used.

This can cause a problem in case the hostname is not specified in `/etc/sysconfig/network` or `/etc/sysconfig/network-scripts/ifcfg-eth*`, where the dhclient would eventually send `localhost` as current hostname, which is obviously wrong.

This PR tries to fix this issue by checking if the hostname is set or not.

Originally reported in [RHBZ #1350602](https://bugzilla.redhat.com/show_bug.cgi?id=1350602).

I'm not sure how `dhclient` behaves in case no hostname is specified, so the review of this commit is especially needed.