### PR TITLE
network-functions: do not send hostname via dhclient everytime

### DIFF
--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -177,7 +177,13 @@ if [ -n "${DYNCONFIG}" -a -x /sbin/dhclient ]; then
             [ -x /sbin/restorecon ] && restorecon /var/lib/dhclient/dhclient-${DEVICE}.leases > /dev/null 2>&1
         fi
     done
-    DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf /var/lib/dhclient/dhclient-${DEVICE}.leases -pf /var/run/dhclient-${DEVICE}.pid"
+
+    if need_hostname; then
+        DHCLIENTARGS="${DHCLIENTARGS} ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    else
+        DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    fi
+
     echo
     echo -n $"Determining IP information for ${DEVICE}..."
     if [[ "${PERSISTENT_DHCLIENT}" !=  [yY1]* ]] && check_link_down ${DEVICE}; then
@@ -307,7 +313,14 @@ if [[ "${DHCPV6C}"  = [Yy1]* ]] && [ -x /sbin/dhclient ]; then
     generate_config_file_name 6
     echo
     echo -n $"Determining IPv6 information for ${DEVICE}..."
-    if /sbin/dhclient -6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf /var/lib/dhclient/dhclient6-${DEVICE}.leases -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE} ; then
+
+    if need_hostname; then
+        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
+    else
+        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE}"
+    fi
+
+    if /sbin/dhclient "$DHCLIENTARGS"; then
         echo $" done."
     else
         echo $" failed."

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -309,13 +309,16 @@ END {
 
 need_hostname ()
 {
-    CHECK_HOSTNAME=$(hostname)
-    if [ "$CHECK_HOSTNAME" = "(none)" -o "$CHECK_HOSTNAME" = "localhost" -o \
-	"$CHECK_HOSTNAME" = "localhost.localdomain" ]; then
-	return 0
-    else
-	return 1
-    fi
+    CHECK_HOSTNAME="$(hostname)"
+
+    case "$CHECK_HOSTNAME" in
+        '(none)' | 'localhost' | 'localhost.localdomain')
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 set_hostname ()


### PR DESCRIPTION
Backport of f134041de3f13776d976bec6d8879a099cfda660 into `rhel6-branch`. Resolves [RHBZ #1350602](https://bugzilla.redhat.com/show_bug.cgi?id=1350602).