### PR TITLE
sysconfig/network: NO_DHCP_HOSTNAME option introduced

### DIFF
--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -186,10 +186,12 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
     generate_config_file_name
     generate_lease_file_name
 
-    if need_hostname; then
-        DHCLIENTARGS="${DHCLIENTARGS} ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
-    else
+    if is_hostname_set; then
+        # We already have the hostname ->> send it to DHCP:
         DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    else
+        # We need to acquire the hostname:
+        DHCLIENTARGS="${DHCLIENTARGS} ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
     fi
 
     echo
@@ -333,10 +335,12 @@ if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
     echo
     echo -n $"Determining IPv6 information for ${DEVICE}..."
 
-    if need_hostname; then
-        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
-    else
+    if is_hostname_set; then
+        # We already have the hostname ->> send it to DHCP:
         DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE}"
+    else
+        # We need to acquire the hostname:
+        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
     fi
 
     if /sbin/dhclient "$DHCLIENTARGS"; then

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -353,18 +353,34 @@ is_available_wait ()
     return $ret
 }
 
-need_hostname ()
+is_hostname_set ()
 {
     CHECK_HOSTNAME="$(hostname)"
 
     case "$CHECK_HOSTNAME" in
         '(none)' | 'localhost' | 'localhost.localdomain')
-            return 0
-            ;;
-        *)
+            # Hostname NOT set:
             return 1
             ;;
+        *)
+            # Hostname IS set:
+            return 0
+            ;;
     esac
+}
+
+need_hostname ()
+{
+    # Should we avoid obtaining hostname from DHCP? (user override)
+    is_true "${NO_DHCP_HOSTNAME}" && return 1
+
+    if is_hostname_set; then
+        # Hostname is already set, we do not need to acquire it:
+        return 1
+    else
+        # Hostname is NOT set, we need to acquire it:
+        return 0
+    fi
 }
 
 set_hostname ()


### PR DESCRIPTION
Previously, some administrators were unable to force initscripts to *NOT* obtain hostname from DHCP, even though they were using static configuration of network. Righ now, setting  `NO_DHCP_HOSTNAME` to `yes`, `true` or `1` in `/etc/sysconfig/network` will allow them to do so.