### PR TITLE
fix typo in IPV6_SET_SYSCTLS

### DIFF
--- a/sysconfig/network-scripts/ifdown-ipv6
+++ b/sysconfig/network-scripts/ifdown-ipv6
@@ -62,7 +62,7 @@ if [ $? != 0 -a $? != 11 ]; then
     exit 1
 fi
 
-if [ ! "$IPV6_SET_SYCTL" = "no" ]; then
+if [ ! "$IPV6_SET_SYSCTLS" = "no" ]; then
     # Switch some sysctls to secure mode
     /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=0 >/dev/null 2>&1
     /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.accept_ra=0 >/dev/null 2>&1


### PR DESCRIPTION
Typo introduced in commit 432951d.

Related: https://github.com/fedora-sysv/initscripts/pull/2
Signed-off-by: Pavel Šimerda <pavlix@pavlix.net>