### PR TITLE
Allow someone to keep accept_ra on while using static addresses.

### DIFF
--- a/sysconfig/network-scripts/ifup-ipv6
+++ b/sysconfig/network-scripts/ifup-ipv6
@@ -121,6 +121,9 @@ else
 	ipv6_local_auto=1
 	if [ "$IPV6_AUTOCONF" = "no" ]; then
 		ipv6_local_auto=0
+		if ! is_true "${IPV6_FORCE_ACCEPT_RA}"; then
+			ipv6_local_accept_ra=0
+		fi
 	fi
 fi
 /sbin/sysctl -e -w net.ipv6.conf.$SYSCTLDEVICE.forwarding=$ipv6_local_forwarding >/dev/null 2>&1


### PR DESCRIPTION
```
It's reasonable (and common) to assign static addresses while still
wanting to get your default gw from your router. The assumption that not
wanting SLAAC means not wanting RA is flawed, but I don't want to break
backwards compatability, so I'm adding an additional option.
```

This is backport of this option in RHEL6. Related to [RHBZ #1086388](https://bugzilla.redhat.com/show_bug.cgi?id=1086388).