### PR TITLE
ipv6_add_addr_on_device: replace the existing address on NIC

### DIFF
--- a/sysconfig/network-scripts/network-functions-ipv6
+++ b/sysconfig/network-scripts/network-functions-ipv6
@@ -177,7 +177,7 @@ ipv6_add_addr_on_device() {
         local address="$address_implicit/$prefixlength_implicit"
     fi
 
-    /sbin/ip -6 addr add $address dev $device
+    /sbin/ip -6 addr replace $address dev $device
     local result=$?
 
     if [ $result -eq 2 ]; then


### PR DESCRIPTION
Instead of adding the IPv6 address when ifup is called, we replace the address, because it might have been auto-assigned before by RA.

This is to assure that static NIC configuration will take effect if the NIC was already dynamically configured by RA.