### PR TITLE
ifup-aliases: we want to call the arping

### DIFF
--- a/sysconfig/network-scripts/ifup-aliases
+++ b/sysconfig/network-scripts/ifup-aliases
@@ -264,7 +264,7 @@ function new_interface ()
                ( grep -qswi "up" /sys/class/net/${parent_device}/operstate ||  grep -qswi "1" /sys/class/net/${parent_device}/carrier ) ; then
                    echo $"Determining if ip address ${IPADDR} is already in use for device ${parent_device}..."
 
-                    ARPING="/sbin/arping -q -c 2 -w ${ARPING_WAIT:-3} -D -I ${parent_device} ${IPADDR}"
+                    ARPING=$(/sbin/arping -q -c 2 -w ${ARPING_WAIT:-3} -D -I ${parent_device} ${IPADDR})
 
                     if [ $? = 1 ]; then
                         ARPINGMAC=$(echo $ARPING |  sed -ne 's/.*\[\(.*\)\].*/\1/p')


### PR DESCRIPTION
It looks that during backport $() was replaced with ""
Resolves: [RHBZ #1413976](https://bugzilla.redhat.com/show_bug.cgi?id=1413976)