### PR TITLE
9.70-1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ SUPERUSER=root
 SUPERGROUP=root
 
 VERSION := $(shell awk '/Version:/ { print $$2 }' initscripts.spec)
-RELEASE := $(shell awk '/Release:/ { print $$2 }' initscripts.spec | sed 's|%{?dist}||g')
-TAG=initscripts-$(VERSION)-$(RELEASE)
+TAG=$(VERSION)
 
 mandir=/usr/share/man
 
@@ -124,15 +123,3 @@ clean:
 tag:
 	@git tag -a -f -m "Tag as $(TAG)" $(TAG)
 	@echo "Tagged as $(TAG)"
-
-archive: clean syntax-check tag changelog
-	@git archive --format=tar --prefix=initscripts-$(VERSION)/ HEAD > initscripts-$(VERSION).tar
-	@mkdir -p initscripts-$(VERSION)/
-	@cp ChangeLog initscripts-$(VERSION)/
-	@tar --append -f initscripts-$(VERSION).tar initscripts-$(VERSION)
-	@bzip2 -f initscripts-$(VERSION).tar
-	@rm -rf initscripts-$(VERSION)
-	@echo "The archive is at initscripts-$(VERSION).tar.bz2"
-	@sha1sum initscripts-$(VERSION).tar.bz2 > initscripts-$(VERSION).sha1sum
-	@scp initscripts-$(VERSION).tar.bz2 initscripts-$(VERSION).sha1sum fedorahosted.org:initscripts 2>/dev/null|| scp initscripts-$(VERSION).tar.bz2 initscripts-$(VERSION).sha1sum fedorahosted.org:/srv/web/releases/i/n/initscripts
-	@echo "Everything done, files uploaded to Fedorahosted.org"

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -1,12 +1,11 @@
 Summary: Scripts to bring up network interfaces and legacy utilities
 Name: initscripts
-Version: 9.69
+Version: 9.70
 License: GPLv2
 Group: System Environment/Base
 Release: 1%{?dist}
-URL: http://fedorahosted.org/releases/i/n/initscripts/
-Source: http://fedorahosted.org/releases/i/n/initscripts/initscripts-%{version}.tar.bz2
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+URL: https://github.com/fedora-sysv/initscripts
+Source: https://github.com/fedora-sysv/initscripts/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Requires: /bin/awk, sed, coreutils
 Requires: grep
 Requires: module-init-tools
@@ -177,6 +176,9 @@ fi
 %{_sysconfdir}/profile.d/debug*
 
 %changelog
+* Fri Feb 24 2017 Lukáš Nykrýn <lnykryn@redhat.com> - 9.70-1
+- move source to github
+
 * Tue Aug 30 2016 David Kaspar [Dee'Kej] <dkaspar@redhat.com> - 9.69-1
 - fedora-import-state should no longer try to create folder with empty name (#1370259)
 


### PR DESCRIPTION
Fedorahosted will be retired next week, so we should move initscripts to github officially.

In the past on fedorahosted, with make archive developer created tarball on his own machine and then copied that to fedorahosted. We should drop that process, since github is able to generate the tarballs for us.

We need to move to a bit different style of labels, since otherwise we will end up with initscripts-initscripts-X.Y in the archive.

So the new workflow for release should be following:
1) prepare a commit with bumped specfile as earlier
2) call make tag instead of make archive
3) git push; git push --tags

In fedora distgit we can use something like this script:
https://src.fedoraproject.org/cgit/rpms/chkconfig.git/commit/?id=912bde26bbfda7b76a0d1e9fe21f321368937587
