### PR TITLE
ifup-eth: remove quote marks

### DIFF
--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -343,7 +343,7 @@ if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
         DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
     fi
 
-    if /sbin/dhclient "$DHCLIENTARGS"; then
+    if /sbin/dhclient $DHCLIENTARGS; then
         echo $" done."
     else
         echo $" failed."


### PR DESCRIPTION
With quote marks all the parameters to dhclient are passed as one
Resolves: rhbz#1431315