### PR TITLE
ifdown-eth: we need to flush global scope as well

### DIFF
--- a/sysconfig/network-scripts/ifdown-eth
+++ b/sysconfig/network-scripts/ifdown-eth
@@ -116,7 +116,10 @@ if [ -d "/sys/class/net/${REALDEVICE}" ]; then
         LABEL="label ${DEVICE}"
     fi
     if [ "${REALDEVICE}" = "lo" ]; then
-        ip addr flush dev ${REALDEVICE} ${LABEL} scope host 2>/dev/null
+        TIMEOUT=""
+        [ -x /usr/bin/timeout ] && TIMEOUT="/usr/bin/timeout --signal=SIGQUIT 4"
+        $TIMEOUT ip addr flush dev ${REALDEVICE} ${LABEL} scope global 2>/dev/null
+        $TIMEOUT ip addr flush dev ${REALDEVICE} ${LABEL} scope host 2>/dev/null
     else
         ip addr flush dev ${REALDEVICE} ${LABEL} scope global 2>/dev/null
         ip -4 addr flush dev ${REALDEVICE} ${LABEL} scope host 2>/dev/null


### PR DESCRIPTION
But it is stuck some time. This is a forward-patch from RHEL6, to allow using
`ifdown` on `loopback` device.