### PR TITLE
killproc/status: add missing '-b <binary>' option

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -183,6 +183,7 @@ __pids_var_run() {
     local base=${1##*/}
     local pid_file=${2:-/var/run/$base.pid}
     local pid_dir=$(/usr/bin/dirname $pid_file > /dev/null)
+    local binary=$3
 
     [ -d "$pid_dir" -a ! -r "$pid_dir" ] && return 4
 
@@ -195,7 +196,13 @@ __pids_var_run() {
             read line
             [ -z "$line" ] && break
             for p in $line ; do
-                [ -z "${p//[0-9]/}" ] && [ -d "/proc/$p" ] && pid="$pid $p"
+                if [ -z "${p//[0-9]/}" ] && [ -d "/proc/$p" ] ; then
+                    if [ -n "$binary" ] ; then
+                        local b=$(readlink /proc/$p/exe | sed -e 's/\s*(deleted)$//')
+                        [ "$b" != "$binary" ] && continue
+                    fi
+                    pid="$pid $p"
+                fi
             done
         done < "$pid_file"
 
@@ -310,7 +317,7 @@ daemon() {
 
 # A function to stop a program.
 killproc() {
-    local RC killlevel= base pid pid_file= delay try
+    local RC killlevel= base pid pid_file= delay try binary=
 
     RC=0; delay=3; try=0
     # Test syntax.
@@ -320,6 +327,15 @@ killproc() {
     fi
     if [ "$1" = "-p" ]; then
         pid_file=$2
+        shift 2
+    fi
+    if [ "$1" = "-b" ]; then
+        if [ -z $pid_file ]; then
+            echo $"-b option can be used only with -p"
+            echo $"Usage: killproc -p pidfile -b binary program"
+            return 1
+        fi
+        binary=$2
         shift 2
     fi
     if [ "$1" = "-d" ]; then
@@ -339,7 +355,7 @@ killproc() {
     base=${1##*/}
 
     # Find pid.
-    __pids_var_run "$1" "$pid_file"
+    __pids_var_run "$1" "$pid_file" "$binary"
     RC=$?
     if [ -z "$pid" ]; then
         if [ -z "$pid_file" ]; then
@@ -425,7 +441,7 @@ pidofproc() {
 }
 
 status() {
-    local base pid lock_file= pid_file=
+    local base pid lock_file= pid_file= binary=
 
     # Test syntax.
     if [ "$#" = 0 ] ; then
@@ -438,6 +454,15 @@ status() {
     fi
     if [ "$1" = "-l" ]; then
         lock_file=$2
+        shift 2
+    fi
+    if [ "$1" = "-b" ]; then
+        if [ -z $pid_file ]; then
+            echo $"-b option can be used only with -p"
+            echo $"Usage: status -p pidfile -b binary program"
+            return 1
+        fi
+        binary=$2
         shift 2
     fi
     base=${1##*/}
@@ -455,7 +480,7 @@ status() {
     fi
 
     # First try "pidof"
-    __pids_var_run "$1" "$pid_file"
+    __pids_var_run "$1" "$pid_file" "$binary"
     RC=$?
     if [ -z "$pid_file" -a -z "$pid" ]; then
         pid="$(__pids_pidof "$1")"


### PR DESCRIPTION
Taken from RHEL-6.9, for forward compatibility.