### PR TITLE
init.d/network: start vpninterfaces

### DIFF
--- a/rc.d/init.d/network
+++ b/rc.d/init.d/network
@@ -74,6 +74,7 @@ case "$1" in
 	vlaninterfaces=""
 	xdslinterfaces=""
 	bridgeinterfaces=""
+	vpninterfaces=""
 
 	# bring up all other interfaces configured to come up at boot time
 	for i in $interfaces; do
@@ -123,7 +124,7 @@ case "$1" in
 	done
 	
 	# Bring up xDSL and VPN interfaces
-	for i in $vlaninterfaces $bridgeinterfaces $xdslinterfaces ; do
+	for i in $vpninterfaces $vlaninterfaces $bridgeinterfaces $xdslinterfaces ; do
             if ! LANG=C egrep -L "^ONBOOT=['\"]?[Nn][Oo]['\"]?" ifcfg-$i >/dev/null 2>&1 ; then
 		# If we're in confirmation mode, get user confirmation.
 		if [ -f /var/run/confirm ]; then
@@ -181,6 +182,7 @@ case "$1" in
 	vlaninterfaces=""
 	xdslinterfaces=""
 	bridgeinterfaces=""
+	vpninterfaces=""
 	remaining=""
 	rc=0
 
@@ -213,7 +215,7 @@ case "$1" in
 		remaining="$remaining $i"
 	done
 	
-	for i in $xdslinterfaces $bridgeinterfaces $vlaninterfaces $remaining; do
+	for i in $xdslinterfaces $bridgeinterfaces $vlaninterfaces $vpninterfaces $remaining; do
 		(. ./ifcfg-$i
 		if [ -z "$DEVICE" ] ; then DEVICE="$i"; fi
 


### PR DESCRIPTION
This is a regression caused by a2ecd685d60fd013b121e78aebd5558121f4fb5e
Resolves: rhbz#1436061