### PR TITLE
Optionally do not send hostname with dhclient -H

### DIFF
--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -186,12 +186,17 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
     generate_config_file_name
     generate_lease_file_name
 
-    if is_hostname_set; then
-        # We already have the hostname ->> send it to DHCP:
-        DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    # Check to see if we should pass -H to dhclient
+    if [ "${DHCP_SEND_HOSTNAME}" = "no" -o "${DHCP_SEND_HOSTNAME}" = "off" ]; then
+        DHCLIENTARGS="${DHCLIENTARGS} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
     else
-        # We need to acquire the hostname:
-        DHCLIENTARGS="${DHCLIENTARGS} ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+        if is_hostname_set; then
+            # We already have the hostname ->> send it to DHCP:
+            DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+        else
+            # We need to acquire the hostname:
+            DHCLIENTARGS="${DHCLIENTARGS} ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+        fi
     fi
 
     echo
@@ -335,12 +340,17 @@ if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
     echo
     echo -n $"Determining IPv6 information for ${DEVICE}..."
 
-    if is_hostname_set; then
-        # We already have the hostname ->> send it to DHCP:
-        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE}"
+    # Check to see if we should pass -H to dhclient
+    if [ "${DHCP6_SEND_HOSTNAME}" = "no" -o "${DHCP6_SEND_HOSTNAME}" = "off" ]; then
+        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DEVICE}"
     else
-        # We need to acquire the hostname:
-        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
+        if is_hostname_set; then
+            # We already have the hostname ->> send it to DHCP:
+            DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE}"
+        else
+            # We need to acquire the hostname:
+            DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
+        fi
     fi
 
     if /sbin/dhclient $DHCLIENTARGS; then


### PR DESCRIPTION
When using DHCP and invoking dhclient, ifup-eth always passes the -H
flag which provides a hostname to the DHCP server.  On systems with
multiple interfaces it is sometimes required for only one interface to
send a hostname.

This patch adds the DHCP_SEND_HOSTNAME and the DHCP6_SEND_HOSTNAME
options which, when set to "no" or "off", remove the -H from the
dhclient command.  These are added to the user's ifcfg-$INTERFACE file.