### PR TITLE
[RHEL-7] rhel-autorelabel: synchronize cached writes before reboot

### DIFF
--- a/systemd/rhel-autorelabel
+++ b/systemd/rhel-autorelabel
@@ -33,6 +33,7 @@ relabel_selinux() {
     fi
     rm -f  /.autorelabel
     /usr/lib/dracut/dracut-initramfs-restore
+    sync
     systemctl --force reboot
 }
 


### PR DESCRIPTION
This should prevent boot loops when 'touch /.autorelabel' has been used. For more info, see [RHBZ #1385272](https://bugzilla.redhat.com/show_bug.cgi?id=1385272).