### PR TITLE
ifup-eth: introduce DHCP_FQDN option

### DIFF
--- a/examples/networking/ifcfg-eth-dhcp
+++ b/examples/networking/ifcfg-eth-dhcp
@@ -7,5 +7,8 @@ DEVICE=eth0
 BOOTPROTO=dhcp
 HWADDR=00:11:22:33:44:55
 ONBOOT=yes
-DHCP_HOSTNAME=host1
 
+# WARNING: When both DHCP_HOSTNAME and DHCP_FQDN are specified,
+#          only DHCP_FQDN will be used.
+DHCP_HOSTNAME=host1
+DHCP_FQDN=host1.foo.bar.com

--- a/sysconfig.txt
+++ b/sysconfig.txt
@@ -550,8 +550,18 @@ Files in /etc/sysconfig/network-scripts/
       With this option set to 'yes' (1), when a dhcp configured
       interface is brought down with 'ifdown', the lease will be
       released. Otherwise, leases are not released.
-    DHCP_HOSTNAME=<name>
+
+    DHCP_SEND_HOSTNAME=yes|no|1|0
+      Tells initscripts whether the DHCP_HOSTNAME or DHCP_FQDN options (below)
+      should be sent to DHCP server.
+    DHCP_HOSTNAME=<hostname>
       Sends the specified hostname to the DHCP server.
+    DHCP_FQDN=<fully.qualified.domain.name>
+      Sends the specified FQDN to the DHCP server.
+
+    Please note when both DHCP_HOSTNAME and DHCP_FQDN are specified,
+    only DHCP_FQDN will be used. (Same behaviour as with NetworkManager.)
+
     DHCLIENT_IGNORE_GATEWAY=yes|no|1|0
       If set to 'yes', it will cause dhclient-script to ignore any $GATEWAY
       setting that may be in the ifcfg file for this interface.

--- a/sysconfig.txt
+++ b/sysconfig.txt
@@ -551,6 +551,10 @@ Files in /etc/sysconfig/network-scripts/
       interface is brought down with 'ifdown', the lease will be
       released. Otherwise, leases are not released.
 
+    NO_DHCP_HOSTNAME=yes|no|1|0
+      Tells initscripts to not obtain hostname from DHCP server in the ifup-post
+      phase. This option might be useful especially with static configuration of
+      the interface.
     DHCP_SEND_HOSTNAME=yes|no|1|0
       Tells initscripts whether the DHCP_HOSTNAME or DHCP_FQDN options (below)
       should be sent to DHCP server.

--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -186,13 +186,9 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
     generate_config_file_name
     generate_lease_file_name
 
-    if is_hostname_set; then
-        # We already have the hostname ->> send it to DHCP:
-        DHCLIENTARGS="${DHCLIENTARGS} -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
-    else
-        # We need to acquire the hostname:
-        DHCLIENTARGS="${DHCLIENTARGS} ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
-    fi
+    # Initialize the dhclient args and obtain the hostname options if needed:
+    DHCLIENTARGS="${DHCLIENTARGS} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    set_hostname_options DHCLIENTARGS
 
     echo
     echo -n $"Determining IP information for ${DEVICE}..."
@@ -335,13 +331,9 @@ if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
     echo
     echo -n $"Determining IPv6 information for ${DEVICE}..."
 
-    if is_hostname_set; then
-        # We already have the hostname ->> send it to DHCP:
-        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid -H ${DHCP_HOSTNAME:-${HOSTNAME%%.*}} ${DEVICE}"
-    else
-        # We need to acquire the hostname:
-        DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DHCP_HOSTNAME:+-H $DHCP_HOSTNAME} ${DEVICE}"
-    fi
+    # Initialize the dhclient args for IPv6 and obtain the hostname options if needed:
+    DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DEVICE}"
+    set_hostname_options DHCLIENTARGS
 
     if /sbin/dhclient $DHCLIENTARGS; then
         echo $" done."

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -397,6 +397,38 @@ need_hostname ()
     fi
 }
 
+set_hostname_options ()
+{
+    # User explicitly requires to *not* send DHCP_HOSTNAME, DHCP_FQDN or HOSTNAME:
+    is_false "${DHCP_SEND_HOSTNAME}" && return
+
+    if [[ -n "${DHCP_HOSTNAME}" && -n "${DHCP_FQDN}" ]]; then
+        net_log $"Both 'DHCP_HOSTNAME=${DHCP_HOSTNAME}' and 'DHCP_FQDN=${DHCP_FQDN}' are configured... Using DHCP_FQDN." warning
+    fi
+
+    local hostname_options=''
+
+    # DHCP_FQDN takes precedence before DHCP_HOSTNAME -- as it does in NetworkManager,
+    # and DHCP_HOSTNAME takes precedence before HOSTNAME:
+    if [[ -n "${DHCP_FQDN}" ]]; then
+        hostname_options="-F ${DHCP_FQDN}"
+    elif [[ -n "${DHCP_HOSTNAME}" ]]; then
+        hostname_options="-H ${DHCP_HOSTNAME}"
+    elif is_hostname_set; then
+        # We need to truncate the hostname in case it is the FQDN:
+        hostname_options="-H ${HOSTNAME%%.*}"
+    else
+        # Nothing to send to the DHCP server:
+        # ['(none)', 'localhost' or 'localhost.localdomain' are not valid]
+        return
+    fi
+
+    # Append the hostname options to the content of passed variable name:
+    eval "$1='${!1} ${hostname_options}'"
+
+    return
+}
+
 set_hostname ()
 {
     hostname $1


### PR DESCRIPTION
The `DHCP_FQDN` is similar to `DHCP_HOSTNAME` option, but it expects the fully qualified domain name to be used there.

In case both `DHCP_HOSTNAME` and `DHCP_FQDN` are set, then the `DHCP_FQDN` will used (*and warning will be produced*). This is the same behaviour as *NetworkManager* does it.