### PR TITLE
re-add missing $HOSTNAME initialization

### DIFF
--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -7,6 +7,10 @@
 PATH="/sbin:/usr/sbin:/bin:/usr/bin"
 export PATH
 
+# We need to initialize the $HOSTNAME variable by ourselves now:
+# (It was previously done for RHEL-6 branch, but got lost in time.)
+HOSTNAME="$(hostname)"
+
 [ -z "$__sed_discard_ignored_files" ] && . /etc/init.d/functions
 
 get_hwaddr ()
@@ -367,9 +371,7 @@ is_available_wait ()
 
 is_hostname_set ()
 {
-    CHECK_HOSTNAME="$(hostname)"
-
-    case "$CHECK_HOSTNAME" in
+    case "${HOSTNAME}" in
         '(none)' | 'localhost' | 'localhost.localdomain')
             # Hostname NOT set:
             return 1

--- a/systemd/fedora-readonly
+++ b/systemd/fedora-readonly
@@ -5,6 +5,10 @@
 
 . /etc/init.d/functions
 
+# We need to initialize the $HOSTNAME variable by ourselves now:
+# (It was previously done for RHEL-6 branch, but got lost in time.)
+HOSTNAME="$(hostname)"
+
 # Check SELinux status
 SELINUX_STATE=
 if [ -e "/sys/fs/selinux/enforce" ] && [ "$(cat /proc/self/attr/current)" != "kernel" ]; then


### PR DESCRIPTION
Previously, the network scripts were using `$HOSTNAME` from `sysconfig/network` configuration, but this has been obsoleted, and the functionality has not been updated properly yet. This commit fixes the issue.