### PR TITLE
usleep: print deprecation warning from now on

### DIFF
--- a/src/usleep.c
+++ b/src/usleep.c
@@ -44,6 +44,9 @@ int main(int argc, char **argv) {
             { 0, 0, 0, 0, 0 }
         };
 
+  fprintf(stderr, "%s: warning: usleep(1) is deprecated, and will be removed in near future!!\n"
+                  "%s: warning: use sleep(1) instead...\n", argv[0], argv[0]);
+
   optCon = poptGetContext("usleep", argc, argv, options,0);
   /*poptReadDefaultConfig(optCon, 1);*/
   poptSetOtherOptionHelp(optCon, "[microseconds]");


### PR DESCRIPTION
For F26 and F27 we will print deprecation warning, trying to move people to use
sleep instead. In F28 the usleep will be completely dropped, hopefully.

This is the initial step to resolve the issue #68.