### PR TITLE
Add *.old to list of ignored files

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -618,7 +618,7 @@ strstr() {
 # Check whether file $1 is a backup or rpm-generated file and should be ignored
 is_ignored_file() {
     case "$1" in
-    *~ | *.bak | *.orig | *.rpmnew | *.rpmorig | *.rpmsave)
+    *~ | *.bak | *.old | *.orig | *.rpmnew | *.rpmorig | *.rpmsave)
         return 0
         ;;
     esac
@@ -670,7 +670,7 @@ apply_sysctl() {
 }
 
 # A sed expression to filter out the files that is_ignored_file recognizes
-__sed_discard_ignored_files='/\(~\|\.bak\|\.orig\|\.rpmnew\|\.rpmorig\|\.rpmsave\)$/d'
+__sed_discard_ignored_files='/\(~\|\.bak\|\.old\|\.orig\|\.rpmnew\|\.rpmorig\|\.rpmsave\)$/d'
 
 if [ "$_use_systemctl" = "1" ]; then
         if  [ "x$1" = xstart -o \

--- a/src/rename_device.c
+++ b/src/rename_device.c
@@ -104,20 +104,40 @@ char *read_subchannels(char *path) {
 
 #endif
 
+/*
+ * Taken from systemd:
+ * https://github.com/systemd/systemd/blob/master/src/basic/string-util.c#L49
+ */
+char* endswith(const char *s, const char *postfix) {
+        size_t sl, pl;
+
+        sl = strlen(s);
+        pl = strlen(postfix);
+
+        if (pl == 0)
+                return (char*) s + sl;
+
+        if (sl < pl)
+                return NULL;
+
+        if (memcmp(s + sl - pl, postfix, pl) != 0)
+                return NULL;
+
+        return (char*) s + sl - pl;
+}
+
 int isCfg(const struct dirent *dent) {
-	int len = strlen(dent->d_name);
-	
-	if (strncmp(dent->d_name,"ifcfg-",6))
+	if (strncmp(dent->d_name, "ifcfg-",6) ||
+	    endswith(dent->d_name, ".rpmnew") != NULL ||
+	    endswith(dent->d_name, ".rpmsave") != NULL ||
+	    endswith(dent->d_name, ".rpmorig") != NULL ||
+	    endswith(dent->d_name, ".orig") != NULL ||
+	    endswith(dent->d_name, ".old") != NULL ||
+	    endswith(dent->d_name, ".bak") != NULL ||
+	    endswith(dent->d_name, "~") != NULL)
 		return 0;
-	if (strstr(dent->d_name,"rpmnew") ||
-	    strstr(dent->d_name,"rpmsave") ||
-	    strstr(dent->d_name,"rpmorig"))
-		return 0;
-	if (dent->d_name[len-1] == '~')
-		return 0;
-	if (!strncmp(dent->d_name+len-4,".bak",4))
-		return 0;
-	return 1;
+	else
+		return 1;
 }
 
 static inline char *dequote(char *start, char *end) {


### PR DESCRIPTION
Turned out in [BZ #1455419](https://bugzilla.redhat.com/show_bug.cgi?id=1455419) that we are not ignoring `*.olg` files, even if we [should](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/sec-Network_Configuration_Using_sysconfig_Files.html).