### PR TITLE
Replace usleep(1) calls with sleep(1) calls

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -154,7 +154,7 @@ __kill_pids_term_kill() {
     [ -z "$kill_list" ] && return 0
 
     kill -TERM $kill_list >/dev/null 2>&1
-    usleep 100000
+    sleep 0.1
 
     kill_list=$(__kill_pids_term_kill_checkpids $base_stime $kill_list)
     if [ -n "$kill_list" ] ; then
@@ -166,7 +166,7 @@ __kill_pids_term_kill() {
         done
         if [ -n "$kill_list" ] ; then
             kill -KILL $kill_list >/dev/null 2>&1
-            usleep 100000
+            sleep 0.1
             kill_list=$(__kill_pids_term_kill_checkpids $base_stime $kill_list)
         fi
     fi

--- a/src/usleep.1
+++ b/src/usleep.1
@@ -7,6 +7,9 @@ usleep \- sleep some number of microseconds
 .SH DESCRIPTION
 .B usleep
 sleeps some number of microseconds.  The default is 1.
+.SH WARNING
+.B usleep
+has been deprecated, and will be removed in near future. Use sleep(1) instead.
 .SH OPTIONS
 \fI--usage\fP
 Show short usage message.
@@ -23,3 +26,5 @@ on precision only to -4 or maybe -5.
 Donald Barnes <djb@redhat.com>
 .br
 Erik Troan <ewt@redhat.com>
+.SH SEE ALSO
+sleep(1)

--- a/sysconfig/network-scripts/ifdown-eth
+++ b/sysconfig/network-scripts/ifdown-eth
@@ -159,7 +159,7 @@ fi
 # wait up to 5 seconds for device to actually come down...
 waited=0
 while ! check_device_down ${DEVICE} && [ "$waited" -lt 50 ] ; do
-    usleep 10000
+    sleep 0.01
     waited=$(($waited+1))
 done
 

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -196,7 +196,11 @@ ethtool_set()
 {
     oldifs=$IFS;
     IFS=';';
-    [ -n "${ETHTOOL_DELAY}" ] && /bin/usleep ${ETHTOOL_DELAY}
+    if [ -n "${ETHTOOL_DELAY}" ]; then
+      # Convert microseconds to seconds:
+      local ETHTOOL_DELAY_SEC=$(awk "BEGIN {printf \"%f\", ${ETHTOOL_DELAY} / 1000000}")
+      sleep ${ETHTOOL_DELAY_SEC}
+    fi
     for opts in $ETHTOOL_OPTS ; do
         IFS=$oldifs;
         if [[ "${opts}" =~ [[:space:]]*- ]]; then
@@ -464,7 +468,7 @@ check_link_down ()
     [ -n "$LINKDELAY" ] && delay=$(($LINKDELAY * 2))
     while [ $timeout -le $delay ]; do
         [ "$(cat /sys/class/net/$REALDEVICE/carrier 2>/dev/null)" != "0" ] && return 1
-        usleep 500000
+        sleep 0.5
         timeout=$((timeout+1))
     done
     return 0


### PR DESCRIPTION
Also, add the deprecation warning into manual page of `usleep(1)`.