### PR TITLE
Check if a dhclient process exists before attempting to kill it

### DIFF
--- a/sysconfig/network-scripts/ifdown-eth
+++ b/sysconfig/network-scripts/ifdown-eth
@@ -94,7 +94,7 @@ for VER in "" 6 ; do
         if is_true "$DHCPRELEASE";  then
             /sbin/dhclient -r -lf ${LEASEFILE} -pf /var/run/dhclient$VER-${DEVICE}.pid ${DEVICE} >/dev/null 2>&1
             retcode=$?
-        else
+        elif kill -0 $dhcpid >/dev/null 2>&1; then
             kill $dhcpid >/dev/null 2>&1
             retcode=$?
             reason=STOP$VER interface=${DEVICE} /sbin/dhclient-script


### PR DESCRIPTION
This makes `ifdown` more resilient when `dhclient` exits uncleanly.

After this fix `ifdown` will return a success exit status and clean up
the pid file left by a failed `dhclient` instance rather than exiting
with 1 when a process it is trying to kill is already gone.

https://bugzilla.redhat.com/show_bug.cgi?id=1472396