### PR TITLE
Drop sysctl.d/00-system.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,10 @@ install:
 	install -m644  debug.csh debug.sh $(ROOT)/etc/profile.d
 	install -m755  sys-unconfig $(ROOT)/usr/sbin
 	install -m644  service.8 sys-unconfig.8 $(ROOT)$(mandir)/man8
-	mkdir -p -m 755 $(ROOT)/usr/lib/sysctl.d
-	mkdir -p -m 755 $(ROOT)/etc/sysctl.d
-	install -m644 sysctl.conf $(ROOT)/usr/lib/sysctl.d/00-system.conf
 	if uname -m | grep -q sparc ; then \
-	  install -m644 sysctl.conf.sparc $(ROOT)/usr/lib/sysctl.d/00-system.conf ; fi
+	  install -D -m644 sysctl.conf.sparc $(ROOT)/usr/lib/sysctl.d/00-system.conf ; fi
 	if uname -m | grep -q s390 ; then \
-	  install -m644 sysctl.conf.s390 $(ROOT)/usr/lib/sysctl.d/00-system.conf ; fi
+	  install -D -m644 sysctl.conf.s390 $(ROOT)/usr/lib/sysctl.d/00-system.conf ; fi
 
 	install -m755 -d $(ROOT)/etc/rc.d $(ROOT)/etc/sysconfig
 	cp -af rc.d/init.d $(ROOT)/etc/rc.d/

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -143,7 +143,6 @@ fi
 %dir %{_sysconfdir}/rc.d/init.d
 %{_sysconfdir}/rc.d/init.d/*
 %ghost %verify(not md5 size mtime) %config(noreplace,missingok) %{_sysconfdir}/rc.d/rc.local
-%{_prefix}/lib/sysctl.d/00-system.conf
 %exclude %{_sysconfdir}/profile.d/debug*
 %{_sysconfdir}/profile.d/*
 %{_sbindir}/sys-unconfig

--- a/sysconfig.txt
+++ b/sysconfig.txt
@@ -127,13 +127,13 @@ Generic options:
        Setting this to 'no' used to disable the magic sysrq key and
        Stop-A (break on serial console) on SPARC. This setting has been
        moved into kernel.sysrq and kernel.stop-a settings respectively in
-       /etc/sysctl.conf. Setting either of them there to 0 disables it,
-       setting it to 1 enables it.
+       sysctl.d/00-system.conf. Setting either of them there to 0 disables
+       it, setting it to 1 enables it.
     STOP_A=yes|no
        Setting this to 'no' used to disable the Stop-A (break on
        serial console) key on SPARC.
        This setting has been moved into kernel.stop-a setting in
-       /etc/sysctl.conf. Setting it there to 0 disables it,
+       sysctl.d/00-system.conf. Setting it there to 0 disables it,
        setting it to 1 enables it. The setting should be present
        on SPARC only.
 
@@ -245,8 +245,8 @@ Generic options:
   obsoleted values from earlier releases:
 
     FORWARD_IPV4=yes|no
-      This setting has been moved into net.ipv4.ip_forward setting
-      in /etc/sysctl.conf. Setting it to 1 there enables IP forwarding,
+      Create a new file in /etc/sysctl.d/ with the net.ipv4.ip_forward
+      setting instead. Setting it to 1 there enables IP forwarding,
       setting it to 0 disables it (which is the default for RFC compliance).
 
     NETWORKWAIT=yes|no

--- a/sysctl.conf
+++ b/sysctl.conf
@@ -1,9 +1,0 @@
-# Kernel sysctl configuration file
-#
-# For binary values, 0 is disabled, 1 is enabled.  See sysctl(8) and
-# sysctl.conf(5) for more details.
-
-# Disable netfilter on bridges.
-net.bridge.bridge-nf-call-ip6tables = 0
-net.bridge.bridge-nf-call-iptables = 0
-net.bridge.bridge-nf-call-arptables = 0


### PR DESCRIPTION
This file now only contains lines to disable netfilter on bridges. In kernel 3.18 this filtering functionality was made non-default by moving it to br_netfilter [BZ #512206](https://bugzilla.redhat.com/show_bug.cgi?id=512206). Anybody who actually wants to use `br_netfilter` has to load it explicitly anyway, so disabling it through sysctl isn't necessary anymore.

The reason for removal is that by default (i.e. when `br_netfilter` is not loaded), we get a warning on every boot (*which is confusing for users and inelegant*):
``` log
systemd-sysctl[210]: Couldn't write '0' to 'net/bridge/bridge-nf-call-ip6tables', ignoring: No such file or directory
systemd-sysctl[210]: Couldn't write '0' to 'net/bridge/bridge-nf-call-iptables', ignoring: No such file or directory
systemd-sysctl[210]: Couldn't write '0' to 'net/bridge/bridge-nf-call-arptables', ignoring: No such file or directory
```
The downside of removing this file is for people who load `br_netfilter` for some reason *and* do no want to use it, will have to take an additional step now (either restore the sysctl settings or remove `br_netfilter` from `/etc/modules-load.d` or wherever). *I expect the number of people affected to be very small.*

(Note that the file was overwritten on sparc and s390, so those architectures see no change.)