### PR TITLE
[Bridge] Wait for STP to complete setup

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -625,6 +625,22 @@ is_ignored_file() {
     return 1
 }
 
+# Convert the value ${1} of time unit ${2}-seconds into seconds:
+convert2sec() {
+  local retval=""
+
+  case "${2}" in
+    deci)   retval=$(awk "BEGIN {printf \"%.1f\", ${1} / 10}") ;;
+    centi)  retval=$(awk "BEGIN {printf \"%.2f\", ${1} / 100}") ;;
+    mili)   retval=$(awk "BEGIN {printf \"%.3f\", ${1} / 1000}") ;;
+    micro)  retval=$(awk "BEGIN {printf \"%.6f\", ${1} / 1000000}") ;;
+    nano)   retval=$(awk "BEGIN {printf \"%.9f\", ${1} / 1000000000}") ;;
+    piko)   retval=$(awk "BEGIN {printf \"%.12f\", ${1} / 1000000000000}") ;;
+  esac
+
+  echo "${retval}"
+}
+
 # Evaluate shvar-style booleans
 is_true() {
     case "$1" in

--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -644,7 +644,7 @@ convert2sec() {
 # Evaluate shvar-style booleans
 is_true() {
     case "$1" in
-    [tT] | [yY] | [yY][eE][sS] | [tT][rR][uU][eE] | 1)
+    [tT] | [yY] | [yY][eE][sS] | [oO][nN] | [tT][rR][uU][eE] | 1)
         return 0
         ;;
     esac
@@ -654,7 +654,7 @@ is_true() {
 # Evaluate shvar-style booleans
 is_false() {
     case "$1" in
-    [fF] | [nN] | [nN][oO] | [fF][aA][lL][sS][eE] | 0)
+    [fF] | [nN] | [nN][oO] | [oO][fF][fF] | [fF][aA][lL][sS][eE] | 0)
         return 0
         ;;
     esac

--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -51,13 +51,16 @@ if [ "${TYPE}" = "Bridge" ]; then
         net_log $"Bridge support not available: brctl not found"
         exit 1
     fi
+
     if [ ! -d /sys/class/net/${DEVICE}/bridge ]; then
         /usr/sbin/brctl addbr -- ${DEVICE} || exit 1
     fi
+
     [ -n "${DELAY}" ] && /usr/sbin/brctl setfd -- ${DEVICE} ${DELAY}
     [ -n "${STP}" ] && /usr/sbin/brctl stp -- ${DEVICE} ${STP}
     [ -n "${PRIO}" ] && /usr/sbin/brctl setbridgeprio ${DEVICE} ${PRIO}
     [ -n "${AGEING}" ] && /usr/sbin/brctl setageing ${DEVICE} ${AGEING}
+
     # add the bits to setup driver parameters here
     for arg in $BRIDGING_OPTS ; do
         key=${arg%%=*};
@@ -66,14 +69,28 @@ if [ "${TYPE}" = "Bridge" ]; then
             echo $value > /sys/class/net/${DEVICE}/bridge/$key
         fi
     done
+
     # set LINKDELAY (used as timeout when calling check_link_down())
     # to at least (${DELAY} * 2) + 7 if STP is enabled. This is the
     # minimum time required for /sys/class/net/$REALDEVICE/carrier to
     # become 1 after "ip link set dev $DEVICE up" is called.
-    if [ "${STP}" = "yes" -o "${STP}" = "on" ]; then
-        TMPD=7
-        [ -n "${DELAY}" ] && TMPD=$(expr ${DELAY} \* 2 + ${TMPD})
-        [ 0$LINKDELAY -lt $TMPD ] && LINKDELAY=$TMPD
+    if is_true "${STP}"; then
+        if [ -n "${DELAY}" ]; then
+          forward_delay="${DELAY}"
+        else
+          # If the ${DELAY} value is not set by the user, then we need to obtain
+          # the forward_delay value from kernel first, and convert it to seconds.
+          # Otherwise STP might not correctly complete the startup before trying
+          # to obtain an IP address from DHCP.
+          forward_delay="$(cat /sys/devices/virtual/net/${DEVICE}/bridge/forward_delay)"
+          forward_delay="$(convert2sec ${forward_delay} centi)"
+        fi
+
+        forward_delay=$(expr ${forward_delay} \* 2 + 7)
+
+        [ 0$LINKDELAY -lt $forward_delay ] && LINKDELAY=$forward_delay
+
+        unset forward_delay
     fi
 fi
 

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -198,7 +198,7 @@ ethtool_set()
     IFS=';';
     if [ -n "${ETHTOOL_DELAY}" ]; then
       # Convert microseconds to seconds:
-      local ETHTOOL_DELAY_SEC=$(awk "BEGIN {printf \"%f\", ${ETHTOOL_DELAY} / 1000000}")
+      local ETHTOOL_DELAY_SEC=$(convert2sec ${ETHTOOL_DELAY} micro)
       sleep ${ETHTOOL_DELAY_SEC}
     fi
     for opts in $ETHTOOL_OPTS ; do


### PR DESCRIPTION
This pull-request contains 2 commits. First introduces an auxiliary function for converting values of time units smaller than 1 second into seconds. The second fixes an issue when bridge can't obtain IP from DHCP right after system start, because `ifup-eth` does not wait for STP to complete its starup ([RHBZ #1380496](https://bugzilla.redhat.com/show_bug.cgi?id=1380496)).

The second commit is based on patch from Richard Alloway (@N3WWN).