### PR TITLE
Replace references to /var/run with /run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,13 @@ install:
 	make install ROOT=$(ROOT) mandir=$(mandir) -C src
 	make install PREFIX=$(ROOT) -C po
 
-	mkdir -p $(ROOT)/var/run/netreport $(ROOT)/var/log
-	chown $(SUPERUSER):$(SUPERGROUP) $(ROOT)/var/run/netreport
-	chmod u=rwx,g=rwx,o=rx $(ROOT)/var/run/netreport
+	mkdir -p $(ROOT)/var/log
+        if -z "$(ROOT)"; then \
+	  # do not touch /run if installing into a chroot
+	  mkdir -p $(ROOT)/run/netreport; \
+	  chown $(SUPERUSER):$(SUPERGROUP) $(ROOT)/run/netreport; \
+	  chmod u=rwx,g=rwx,o=rx $(ROOT)/run/netreport; \
+	fi
 
 	for i in 0 1 2 3 4 5 6 ; do \
 		dir=$(ROOT)/etc/rc.d/rc$$i.d; \

--- a/initscripts.tmpfiles.d
+++ b/initscripts.tmpfiles.d
@@ -1,2 +1,2 @@
 
-d /var/run/netreport 0775 root root -
+d /run/netreport 0775 root root -

--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -176,12 +176,12 @@ __kill_pids_term_kill() {
 }
 
 # __proc_pids {program} [pidfile]
-# Set $pid to pids from /var/run* for {program}.  $pid should be declared
+# Set $pid to pids from /run* for {program}.  $pid should be declared
 # local in the caller.
 # Returns LSB exit code for the 'status' action.
 __pids_var_run() {
     local base=${1##*/}
-    local pid_file=${2:-/var/run/$base.pid}
+    local pid_file=${2:-/run/$base.pid}
     local pid_dir=$(/usr/bin/dirname $pid_file > /dev/null)
     local binary=$3
 
@@ -209,7 +209,7 @@ __pids_var_run() {
             if [ -n "$pid" ]; then
                     return 0
             fi
-        return 1 # "Program is dead and /var/run pid file exists"
+        return 1 # "Program is dead and /run pid file exists"
     fi
     return 3 # "Program is not running"
 }
@@ -393,7 +393,7 @@ killproc() {
 
     # Remove pid file if any.
     if [ -z "$killlevel" ]; then
-        rm -f "${pid_file:-/var/run/$base.pid}"
+        rm -f "${pid_file:-/run/$base.pid}"
     fi
     return $RC
 }
@@ -428,7 +428,7 @@ pidofproc() {
     fi
     fail_code=3 # "Program is not running"
 
-    # First try "/var/run/*.pid" files
+    # First try "/run/*.pid" files
     __pids_var_run "$1" "$pid_file"
     RC=$?
     if [ -n "$pid" ]; then

--- a/src/netreport.c
+++ b/src/netreport.c
@@ -34,7 +34,7 @@ usage(void) {
 #define DEL 0
 int main(int argc, char ** argv) {
     int action = ADD;
-    /* more than long enough for "/var/run/netreport/<pid>\0" */
+    /* more than long enough for "/run/netreport/<pid>\0" */
     char netreport_name[64];
     int  netreport_file;
 
@@ -51,7 +51,7 @@ int main(int argc, char ** argv) {
     }
 
     snprintf(netreport_name, sizeof(netreport_name),
-	     "/var/run/netreport/%d", getppid());
+	     "/run/netreport/%d", getppid());
     if (action == ADD) {
 	netreport_file = open(netreport_name,
 			      O_EXCL|O_CREAT|O_WRONLY|O_TRUNC|O_NOFOLLOW, 0);

--- a/sysconfig.txt
+++ b/sysconfig.txt
@@ -227,7 +227,7 @@ Generic options:
 
   IPV6_RADVD_PIDFILE=<pid-file> (optional)
     Location of PID file for controlling radvd, see IPV6_CONTROL_RADVD
-    Default: "/var/run/radvd/radvd.pid"
+    Default: "/run/radvd/radvd.pid"
     Example:
        IPV6_RADVD_PIDFILE="/some/other/location/radvd.pid"
   IPV6TO4_RADVD_PIDFILE=<pid-file> (obsolete)
@@ -376,7 +376,7 @@ Generic options:
     controls which data source saslauthd will consult when checking user
     passwords; run 'saslauthd -v' to get a full list of available
     authentication mechanisms
-  SOCKETDIR=/var/run/saslauthd
+  SOCKETDIR=/run/saslauthd
     controls in which directory saslauthd will be directed to create its
     listening socket; any change to this value will require a corresponding
     change in client configuration files

--- a/sysconfig/network-scripts/ifdown-bnep
+++ b/sysconfig/network-scripts/ifdown-bnep
@@ -18,12 +18,12 @@ fi
 
 stop_panu()
 {
-    kill -TERM $(cat /var/run/pand-${DEVICE}.pid)
+    kill -TERM $(cat /run/pand-${DEVICE}.pid)
 }
 
 stop_nap()
 {
-    kill -TERM $(cat /var/run/pand-${DEVICE}.pid)
+    kill -TERM $(cat /run/pand-${DEVICE}.pid)
     /usr/bin/pand -K
 }
 

--- a/sysconfig/network-scripts/ifdown-eth
+++ b/sysconfig/network-scripts/ifdown-eth
@@ -88,19 +88,19 @@ fi
 retcode=0
 [ -n "$(pidof -x dhclient)" ] && {
 for VER in "" 6 ; do
-    if [ -f "/var/run/dhclient$VER-${DEVICE}.pid" ]; then
-        dhcpid=$(cat /var/run/dhclient$VER-${DEVICE}.pid)
+    if [ -f "/run/dhclient$VER-${DEVICE}.pid" ]; then
+        dhcpid=$(cat /run/dhclient$VER-${DEVICE}.pid)
         generate_lease_file_name $VER
         if is_true "$DHCPRELEASE";  then
-            /sbin/dhclient -r -lf ${LEASEFILE} -pf /var/run/dhclient$VER-${DEVICE}.pid ${DEVICE} >/dev/null 2>&1
+            /sbin/dhclient -r -lf ${LEASEFILE} -pf /run/dhclient$VER-${DEVICE}.pid ${DEVICE} >/dev/null 2>&1
             retcode=$?
         else
             kill $dhcpid >/dev/null 2>&1
             retcode=$?
             reason=STOP$VER interface=${DEVICE} /sbin/dhclient-script
         fi
-        if [ -f "/var/run/dhclient$VER-${DEVICE}.pid" ]; then
-            rm -f /var/run/dhclient$VER-${DEVICE}.pid
+        if [ -f "/run/dhclient$VER-${DEVICE}.pid" ]; then
+            rm -f /run/dhclient$VER-${DEVICE}.pid
             kill $dhcpid >/dev/null 2>&1
         fi  
     fi
@@ -140,7 +140,7 @@ if [ -n "${BRIDGE}" ] && [ -x /usr/sbin/brctl ]; then
     /usr/sbin/brctl delif -- ${BRIDGE} ${DEVICE}
     # Upon removing a device from a bridge,
     # it's necessary to make radvd reload its config
-    [ -r /var/run/radvd/radvd.pid ] && kill -HUP $(cat /var/run/radvd/radvd.pid)
+    [ -r /run/radvd/radvd.pid ] && kill -HUP $(cat /run/radvd/radvd.pid)
     if [ -d /sys/class/net/${BRIDGE}/brif ] && [ $(ls -1 /sys/class/net/${BRIDGE}/brif | wc -l) -eq 0 ]; then
         /usr/sbin/brctl delbr -- ${BRIDGE}
     fi

--- a/sysconfig/network-scripts/ifdown-ippp
+++ b/sysconfig/network-scripts/ifdown-ippp
@@ -27,8 +27,8 @@ ip link set dev $DEVICE down >/dev/null 2>&1
 isdnctrl delif $DEVICE >/dev/null 2>&1
 
 # kill ipppd daemon
-if [ -f /var/run/ipppd.$DEVICE.pid ] ; then
-    pppdpid=$(cat /var/run/ipppd.$DEVICE.pid)
+if [ -f /run/ipppd.$DEVICE.pid ] ; then
+    pppdpid=$(cat /run/ipppd.$DEVICE.pid)
     kill -9 $pppdpid > /dev/null 2>&1
-    rm -f /var/run/ipppd.$DEVICE.pid > /dev/null 2>&1
+    rm -f /run/ipppd.$DEVICE.pid > /dev/null 2>&1
 fi

--- a/sysconfig/network-scripts/ifdown-ipv6
+++ b/sysconfig/network-scripts/ifdown-ipv6
@@ -26,7 +26,7 @@
 #
 # Optional for 6to4 tunneling links to trigger radvd:
 #  IPV6_CONTROL_RADVD=yes|no: controls radvd triggering [optional]
-#  IPV6_RADVD_PIDFILE=<file>: PID file of radvd for sending signals, default is "/var/run/radvd/radvd.pid" [optional]
+#  IPV6_RADVD_PIDFILE=<file>: PID file of radvd for sending signals, default is "/run/radvd/radvd.pid" [optional]
 #  IPV6_RADVD_TRIGGER_ACTION=startstop|reload|restart|SIGHUP: how to trigger radvd [optional, default is SIGHUP]
 #
 #  Required version of radvd to use 6to4 prefix recalculation

--- a/sysconfig/network-scripts/ifup-bnep
+++ b/sysconfig/network-scripts/ifup-bnep
@@ -18,7 +18,7 @@ fi
 
 start_panu()
 {
-    PANDARGS="--persist --pidfile=/var/run/pand-${DEVICE}.pid --ethernet=${DEVICE} --autozap"
+    PANDARGS="--persist --pidfile=/run/pand-${DEVICE}.pid --ethernet=${DEVICE} --autozap"
     [ "${CACHE}" != "no" -a "${CACHE}" != "NO" ] && PANDARGS="${PANDARGS} --cache"
     if [ "${REMOTEBDADDR}" = "" ]; then
         PANDARGS="${PANDARGS} --search"

--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -173,7 +173,7 @@ if [ -n "${BRIDGE}" ] && [ -x /usr/sbin/brctl ]; then
     done
     # Upon adding a device to a bridge,
     # it's necessary to make radvd reload its config
-    [ -r /var/run/radvd/radvd.pid ] && kill -HUP $(cat /var/run/radvd/radvd.pid)
+    [ -r /run/radvd/radvd.pid ] && kill -HUP $(cat /run/radvd/radvd.pid)
     exit 0
 fi
 
@@ -187,7 +187,7 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
     generate_lease_file_name
 
     # Initialize the dhclient args and obtain the hostname options if needed:
-    DHCLIENTARGS="${DHCLIENTARGS} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient-${DEVICE}.pid"
+    DHCLIENTARGS="${DHCLIENTARGS} ${ONESHOT} -q ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /run/dhclient-${DEVICE}.pid"
     set_hostname_options DHCLIENTARGS
 
     echo
@@ -332,7 +332,7 @@ if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
     echo -n $"Determining IPv6 information for ${DEVICE}..."
 
     # Initialize the dhclient args for IPv6 and obtain the hostname options if needed:
-    DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /var/run/dhclient6-${DEVICE}.pid ${DEVICE}"
+    DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /run/dhclient6-${DEVICE}.pid ${DEVICE}"
     set_hostname_options DHCLIENTARGS
 
     if /sbin/dhclient $DHCLIENTARGS; then

--- a/sysconfig/network-scripts/ifup-ipv6
+++ b/sysconfig/network-scripts/ifup-ipv6
@@ -43,7 +43,7 @@
 #
 # Optional for 6to4 tunneling to trigger radvd:
 #  IPV6_CONTROL_RADVD=yes|no: controls radvd triggering (optional)
-#  IPV6_RADVD_PIDFILE=<file>: PID file of radvd for sending signals, default is "/var/run/radvd/radvd.pid" (optional)
+#  IPV6_RADVD_PIDFILE=<file>: PID file of radvd for sending signals, default is "/run/radvd/radvd.pid" (optional)
 #  IPV6_RADVD_TRIGGER_ACTION=startstop|reload|restart|SIGHUP: how to trigger radvd (optional, default is SIGHUP)
 #
 #  Required version of radvd to use 6to4 prefix recalculation

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -283,7 +283,7 @@ do_netreport ()
 {
     # Notify programs that have requested notification
     (
-        cd /var/run/netreport || exit
+        cd /run/netreport || exit
         for i in * ; do
             if [ -f $i ]; then
                 if [ "$(id -u)" = "0" ]; then
@@ -654,7 +654,7 @@ change_resolv_conf ()
     if [ $r -eq 0 ]; then
         [ -x /sbin/restorecon ] && /sbin/restorecon /etc/resolv.conf >/dev/null 2>&1 # reset the correct context
         /usr/bin/logger -p local7.notice -t "NET" -i "$0 : updated /etc/resolv.conf"
-        [ -e /var/run/nscd/socket ] && /usr/sbin/nscd -i hosts # invalidate cache
+        [ -e /run/nscd/socket ] && /usr/sbin/nscd -i hosts # invalidate cache
     fi
     return $r
 }

--- a/sysconfig/network-scripts/network-functions-ipv6
+++ b/sysconfig/network-scripts/network-functions-ipv6
@@ -971,7 +971,7 @@ ipv6_trigger_radvd() {
     fi
 
     if [ -z "$pidfile" ]; then
-        local pidfile="/var/run/radvd/radvd.pid"
+        local pidfile="/run/radvd/radvd.pid"
     fi
 
     # Print message and select action


### PR DESCRIPTION
A small cleanup, I hope there's no functional change, except when for whatever reason /var is not mounted and the /var/run → /run symlink is missing.