### PR TITLE
Makefile: $ROOT variable is now empty by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ROOT=/
+ROOT=
 SUPERUSER=root
 SUPERGROUP=root
 


### PR DESCRIPTION
This will avoid `/` duplicating at the path beginning, and should make the patch from @keszybz finally work. :)