### PR TITLE
Remove symlinks for fedora-* services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,6 @@ install:
 	done
 
 # Can't store symlinks in a CVS archive
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/multi-user.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/graphical.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/local-fs.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/sysinit.target.wants
-	ln -s ../fedora-loadmodules.service $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	ln -s ../fedora-readonly.service $(ROOT)/usr/lib/systemd/system/local-fs.target.wants
-	ln -s ../fedora-import-state.service $(ROOT)/usr/lib/systemd/system/local-fs.target.wants
-
 	mkdir -p $(ROOT)/usr/lib/tmpfiles.d
 	install -m 644 initscripts.tmpfiles.d $(ROOT)/usr/lib/tmpfiles.d/initscripts.conf
 

--- a/systemd/system/fedora-domainname.service
+++ b/systemd/system/fedora-domainname.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Read and set NIS domainname from /etc/sysconfig/network
-Before=ypbind.service yppasswdd.service ypserv.service ypxfrd.service
+Before=ypbind.service yppasswdd.service ypserv.service ypxfrd.service sysinit.target
 DefaultDependencies=no
 Conflicts=shutdown.target
 
 [Service]
-ExecStart=/lib/systemd/fedora-domainname
+ExecStart=/usr/lib/systemd/fedora-domainname
 Type=oneshot
 RemainAfterExit=yes
 

--- a/systemd/system/fedora-import-state.service
+++ b/systemd/system/fedora-import-state.service
@@ -4,11 +4,14 @@ DefaultDependencies=no
 ConditionPathIsReadWrite=/
 ConditionDirectoryNotEmpty=/run/initramfs/state
 Conflicts=shutdown.target
-Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup.service basic.target
+Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup.service sysinit.target
 After=local-fs.target
 
 [Service]
-ExecStart=/lib/systemd/fedora-import-state
+ExecStart=/usr/lib/systemd/fedora-import-state
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/system/fedora-loadmodules.service
+++ b/systemd/system/fedora-loadmodules.service
@@ -7,7 +7,10 @@ ConditionPathExists=|/etc/rc.modules
 ConditionDirectoryNotEmpty=|/etc/sysconfig/modules/
 
 [Service]
-ExecStart=/lib/systemd/fedora-loadmodules
+ExecStart=/usr/lib/systemd/fedora-loadmodules
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/system/fedora-readonly.service
+++ b/systemd/system/fedora-readonly.service
@@ -6,7 +6,10 @@ Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup
 After=systemd-remount-fs.service
 
 [Service]
-ExecStart=/lib/systemd/fedora-readonly
+ExecStart=/usr/lib/systemd/fedora-readonly
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
These symlinks are no longer needed, because services enabled by default are now managed by `fedora-release` package.

Before merging this PR/releasing new version of initscripts, we should wait for necessary changes to be made in `fedora-release`.