### PR TITLE
[RHEL7] Remove symlinks for initscripts' services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,21 +84,6 @@ install:
 		chmod u=rwx,g=rx,o=rx $$dir; \
 	done
 
-# Can't store symlinks in a CVS archive
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/multi-user.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/graphical.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/local-fs.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	mkdir -p -m 755 $(ROOT)/usr/lib/systemd/system/sysinit.target.wants
-	ln -s ../rhel-configure.service $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	ln -s ../rhel-loadmodules.service $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	ln -s ../rhel-autorelabel.service $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	ln -s ../rhel-autorelabel-mark.service $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	ln -s ../rhel-dmesg.service $(ROOT)/usr/lib/systemd/system/basic.target.wants
-	ln -s ../rhel-readonly.service $(ROOT)/usr/lib/systemd/system/local-fs.target.wants
-	ln -s ../rhel-import-state.service $(ROOT)/usr/lib/systemd/system/local-fs.target.wants
-	ln -s ../brandbot.path $(ROOT)/usr/lib/systemd/system/multi-user.target.wants
-
 	mkdir -p $(ROOT)/usr/lib/tmpfiles.d
 	install -m 644 initscripts.tmpfiles.d $(ROOT)/usr/lib/tmpfiles.d/initscripts.conf
 

--- a/systemd/system/rhel-autorelabel-mark.service
+++ b/systemd/system/rhel-autorelabel-mark.service
@@ -10,6 +10,9 @@ ConditionPathIsDirectory=/etc/selinux
 ConditionPathExists=!/.autorelabel
 
 [Service]
-ExecStart=-/bin/touch /.autorelabel
+ExecStart=-/usr/bin/touch /.autorelabel
 Type=oneshot
 RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/system/rhel-autorelabel.service
+++ b/systemd/system/rhel-autorelabel.service
@@ -10,8 +10,11 @@ ConditionKernelCommandLine=|autorelabel
 ConditionPathExists=|/.autorelabel
 
 [Service]
-ExecStart=/lib/systemd/rhel-autorelabel
+ExecStart=/usr/lib/systemd/rhel-autorelabel
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
 StandardInput=tty
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/system/rhel-configure.service
+++ b/systemd/system/rhel-configure.service
@@ -7,9 +7,12 @@ After=local-fs.target
 ConditionPathExists=/.unconfigured
 
 [Service]
-ExecStart=/lib/systemd/rhel-configure
+ExecStart=/usr/lib/systemd/rhel-configure
 ExecStopPost=/bin/rm -f /.unconfigured
 Type=oneshot
 TimeoutSec=0
 StandardInput=tty
 RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/system/rhel-domainname.service
+++ b/systemd/system/rhel-domainname.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Read and set NIS domainname from /etc/sysconfig/network
-Before=ypbind.service yppasswdd.service ypserv.service ypxfrd.service
+Before=ypbind.service yppasswdd.service ypserv.service ypxfrd.service sysinit.target
 DefaultDependencies=no
 Conflicts=shutdown.target
 
 [Service]
-ExecStart=/lib/systemd/rhel-domainname
+ExecStart=/usr/lib/systemd/rhel-domainname
 Type=oneshot
 RemainAfterExit=yes
 

--- a/systemd/system/rhel-import-state.service
+++ b/systemd/system/rhel-import-state.service
@@ -4,11 +4,14 @@ DefaultDependencies=no
 ConditionPathIsReadWrite=/
 ConditionDirectoryNotEmpty=/run/initramfs/state
 Conflicts=shutdown.target
-Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup.service basic.target
+Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup.service sysinit.target
 After=local-fs.target
 
 [Service]
-ExecStart=/lib/systemd/rhel-import-state
+ExecStart=/usr/lib/systemd/rhel-import-state
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/system/rhel-loadmodules.service
+++ b/systemd/system/rhel-loadmodules.service
@@ -8,7 +8,10 @@ ConditionPathExists=|/etc/rc.modules
 ConditionDirectoryNotEmpty=|/etc/sysconfig/modules/
 
 [Service]
-ExecStart=/lib/systemd/rhel-loadmodules
+ExecStart=/usr/lib/systemd/rhel-loadmodules
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/systemd/system/rhel-readonly.service
+++ b/systemd/system/rhel-readonly.service
@@ -6,7 +6,10 @@ Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup
 After=systemd-remount-fs.service
 
 [Service]
-ExecStart=/lib/systemd/rhel-readonly
+ExecStart=/usr/lib/systemd/rhel-readonly
 Type=oneshot
 TimeoutSec=0
 RemainAfterExit=yes
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
These symlinks are no longer needed, because services enabled by default are now managed by `redhat-release` package.

Before merging this PR/releasing new version of initscripts, we should wait for necessary changes to be made in `redhat-release`.]

This PR fixes [BZ #1395391](https://bugzilla.redhat.com/show_bug.cgi?id=1395391) and [BZ #1357648](https://bugzilla.redhat.com/show_bug.cgi?id=1357648).