### PR TITLE
usleep: change the error message to print the full replacement commadline

### DIFF
--- a/src/usleep.c
+++ b/src/usleep.c
@@ -44,9 +44,6 @@ int main(int argc, char **argv) {
             { 0, 0, 0, 0, 0 }
         };
 
-  fprintf(stderr, "%s: warning: usleep(1) is deprecated, and will be removed in near future!!\n"
-                  "%s: warning: use sleep(1) instead...\n", argv[0], argv[0]);
-
   optCon = poptGetContext("usleep", argc, argv, options,0);
   /*poptReadDefaultConfig(optCon, 1);*/
   poptSetOtherOptionHelp(optCon, "[microseconds]");
@@ -79,6 +76,9 @@ int main(int argc, char **argv) {
   }
 
   else count = strtoul(countStr, NULL, 0); 
+
+  fprintf(stderr, "warning: usleep is deprecated, and will be removed in near future!\n"
+	          "warning: use \"sleep %.7g\" instead...\n", count / 1e6);
 
   usleep(count);
   return 0;


### PR DESCRIPTION
Also drop the argv[0] as previx — the message already includes the
name of the program.

$ ./src/usleep 300
warning: usleep is deprecated, and will be removed in near future!
warning: use "sleep 0.3" instead...

%g will print a normal decimal point for all values that are likely to
be used (the smallest one possible is 1/1000 = 0.001). For very large
values scientific notation will be used, which is not very pretty, but
sleep accepts that, so there's no issue.

https://bugzilla.redhat.com/show_bug.cgi?id=1494168