### PR TITLE
[specfile] drop dependency on /etc/system-release completely

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -19,8 +19,6 @@ Conflicts: dmraid < 1.0.0.rc16-18
 Conflicts: policycoreutils < 2.5-6
 Requires: systemd
 Requires: iproute, /sbin/arping, findutils
-# Not strictly required, but nothing else requires it
-Requires: /etc/system-release
 Requires: cpio
 Requires: hostname
 Conflicts: ipsec-tools < 0.8.0-2


### PR DESCRIPTION
This way the `fedora-release` will be still installed by default together with initscripts, but initscripts will no longer block users from unistalling `fedora-release`, if they require so.

IOW, the Fedora branding will not be forced by initscripts any more.