### PR TITLE
[RHEL7] use weak (instead of strong) dependency for 'redhat-release'

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -22,8 +22,7 @@ Conflicts: lvm2 < 2.02.100-5
 Conflicts: dmraid < 1.0.0.rc16-18
 Requires: systemd
 Requires: iproute, /sbin/arping, findutils
-# Not strictly required, but nothing else requires it
-Requires: /etc/system-release
+Recommends: redhat-release
 Requires: udev >= 125-1
 Requires: cpio
 Requires: hostname


### PR DESCRIPTION
Same as #136, but for `redhat-release` and *RHEL-7*...