### PR TITLE
network: add knob to optionally keep interfaces up during shutdown

### DIFF
--- a/rc.d/init.d/network
+++ b/rc.d/init.d/network
@@ -167,6 +167,15 @@ stop)
         exit 1
     fi
 
+    # Don't shut the network down when shutting down the system if configured
+    # as such in sysconfig
+    if [ "$IFDOWN_ON_SHUTDOWN" = no ]; then
+      if systemctl is-system-running | grep -q 'stopping'; then
+        net_log "system is shutting down, leaving interfaces up as requested"
+        exit 1
+      fi
+    fi
+
     vlaninterfaces=""
     vpninterfaces=""
     xdslinterfaces=""

--- a/rc.d/init.d/network
+++ b/rc.d/init.d/network
@@ -169,9 +169,9 @@ stop)
 
     # Don't shut the network down when shutting down the system if configured
     # as such in sysconfig
-    if [ "$IFDOWN_ON_SHUTDOWN" = no ]; then
+    if is_false "$IFDOWN_ON_SHUTDOWN"; then
       if systemctl is-system-running | grep -q 'stopping'; then
-        net_log "system is shutting down, leaving interfaces up as requested"
+        net_log $"system is shutting down, leaving interfaces up as requested"
         exit 1
       fi
     fi

--- a/sysconfig.txt
+++ b/sysconfig.txt
@@ -178,6 +178,11 @@ Generic options:
     network has spanning tree running and must wait for STP convergence.
     Default: 0 (no delay)
 
+  IFDOWN_ON_SHUTDOWN=yes|no
+    If yes, do bring interfaces down during system shutdown. If no, leave them
+    in their current state (this is only supported on hosts using systemd).
+    Default: yes (bring interfaces down)
+
 
   IPV6FORWARDING=yes|no
     Enable or disable global forwarding of incoming IPv6 packets 


### PR DESCRIPTION
On machines that use systemd as PID1 but don't enable pam_systemd, SSH sessions aren't terminated properly on shutdown (see https://bugzilla.redhat.com/show_bug.cgi?id=1047614 for details). This PR adds a knob to workaround the issue, by optionally leaving the network up during shutdown. This is only implemented for systemd hosts, but it could be extended to SysV ones as well if desired.