### PR TITLE
ifdown-post: fix logical error in commit 5d61564

### DIFF
--- a/sysconfig/network-scripts/ifdown-post
+++ b/sysconfig/network-scripts/ifdown-post
@@ -22,7 +22,7 @@ source_config
 # to have always correct condition below...
 update_DNS_entries
 
-if ! is_false "${PEERDNS}" || ! is_false "${RESOLV_MODS}" && \
+if ! is_false "${PEERDNS}" || is_true "${RESOLV_MODS}" && \
     [ "${DEVICETYPE}" = "ppp" -o "${DEVICETYPE}" = "ippp" -o -n "${DNS1}" \
     -o "${BOOTPROTO}" = "bootp" -o "${BOOTPROTO}" = "dhcp" ] ; then
     if [ -f /etc/resolv.conf.save ]; then


### PR DESCRIPTION
Empty `${RESOLV_MODS}` was causing a deletion of config files in `/etc/ppp/peers/`.

Resolves: #155