### PR TITLE
service: check for 'status' support when doing '--status-all'

### DIFF
--- a/service
+++ b/service
@@ -45,7 +45,11 @@ while [ $# -gt 0 ]; do
               *)
                 if ! is_ignored_file "${SERVICE}" \
 		    && [ -x "${SERVICEDIR}/${SERVICE}" ]; then
-                  env -i PATH="$PATH" TERM="$TERM" "${SERVICEDIR}/${SERVICE}" status
+                  if grep -e "'status'" -e '\"status\"' -e 'status[[:blank:]]*)' "${SERVICEDIR}/${SERVICE}" > /dev/null 2>&1; then
+                    env -i PATH="$PATH" TERM="$TERM" "${SERVICEDIR}/${SERVICE}" status
+                  else
+                    echo $"Warning: ${SERVICEDIR}/${SERVICE} does not support reporting of its status" >&2
+                  fi
                 fi
                 ;;
             esac


### PR DESCRIPTION
To avoid calling of `status` on some non-LSB compliant initscripts. This is not perfect and is *best-effort only*, because some crazily written initscripts might have different way of checking/displaying of `status`.

We print a warning when we stumble on a script that we assume does not have the `status` functionality implemented. I expect us to receive a bug report for a script that implements `status` in some strange way, so we will add the regex pattern for it if needed.