### PR TITLE
init.d/functions: fix sourcing for ksh

### DIFF
--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -148,8 +148,13 @@ __kill_pids_term_kill() {
     local try=0
     local delay=3;
     local pid=
-    local stat=($(< /proc/self/stat))
-    local base_stime=${stat[21]}
+    local stat=
+    local base_stime=
+
+    # We can't initialize stat & base_stime on the same line where 'local'
+    # keyword is, otherwise the sourcing of this file will fail for ksh...
+    stat=($(< /proc/self/stat))
+    base_stime=${stat[21]}
 
     if [ "$1" = "-d" ]; then
         delay=$2


### PR DESCRIPTION
More info: https://bugzilla.redhat.com/show_bug.cgi?id=1518429