### PR TITLE
rhel-readonly.service: target name for random seed fixed

### DIFF
--- a/systemd/system/rhel-readonly.service
+++ b/systemd/system/rhel-readonly.service
@@ -2,7 +2,7 @@
 Description=Configure read-only root support
 DefaultDependencies=no
 Conflicts=shutdown.target
-Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup.service local-fs.target systemd-random-seed-load.service
+Before=shutdown.target emergency.service emergency.target systemd-tmpfiles-setup.service local-fs.target systemd-random-seed.service
 After=systemd-remount-fs.service
 
 [Service]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1553093