### PR TITLE
specfile: remove the systemctl call in the %postun phase

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -72,13 +72,6 @@ fi
 %postun
 %systemd_postun fedora-import-state.service fedora-loadmodules.service fedora-readonly.service
 
-# This should be removed in Rawhide for Fedora 29:
-%triggerun -- initscripts < 9.78
-if [ $1 -gt 1 ]; then
-  systemctl enable fedora-import-state.service fedora-readonly.service &> /dev/null || :
-  echo -e "\nUPGRADE: Automatically re-enabling default systemd units: fedora-import-state.service fedora-readonly.service\n" || :
-fi
-
 %files -f %{name}.lang
 %defattr(-,root,root)
 %dir %{_sysconfdir}/sysconfig/network-scripts


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1512688 for more info.

NOTE: We shouldn't merge this commit until F28 is released as GA - to make sure the upgrades go smoothly... :)