### PR TITLE
use proper shebang

### DIFF
--- a/service
+++ b/service
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /etc/init.d/functions
 

--- a/sys-unconfig
+++ b/sys-unconfig
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /etc/init.d/functions
 

--- a/sysconfig/network-scripts/ifdown-sit
+++ b/sysconfig/network-scripts/ifdown-sit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # ifdown-sit
 #

--- a/sysconfig/network-scripts/ifup-ipv6
+++ b/sysconfig/network-scripts/ifup-ipv6
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # ifup-ipv6
 #

--- a/sysconfig/network-scripts/init.ipv6-global
+++ b/sysconfig/network-scripts/init.ipv6-global
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # init.ipv6-global
 #


### PR DESCRIPTION
$" is a BASH extension to translate text.
Replace the shebang with /bin/bash to avoid parsing errors,
as even BASH has a POSIX compliant mode when run as sh.

Signed-off-by: Matteo Croce <mcroce@redhat.com>