### PR TITLE
network: add option to keep the link down

### DIFF
--- a/sysconfig/network-scripts/ifup
+++ b/sysconfig/network-scripts/ifup
@@ -116,7 +116,7 @@ if [ "${VLAN}" = "yes" ] && [ "$ISALIAS" = "no" ] && [ -n "$DEVICE" ]; then
         }
 
         # Link on Physical device needs to be up but no ip required
-        check_device_down ${PHYSDEV} && { ip -o link set dev ${PHYSDEV} up; }
+        check_device_down ${PHYSDEV} && set_link_up ${PHYSDEV} up
 
         if [ ! -f /proc/net/vlan/${DEVICE} ]; then
             if [ "${REORDER_HDR}" = "no" -o "${REORDER_HDR}" = "0" ]; then

--- a/sysconfig/network-scripts/ifup-ctc
+++ b/sysconfig/network-scripts/ifup-ctc
@@ -26,7 +26,7 @@ fi
 
 [ -z "$PREFIX" ] && eval $(/bin/ipcalc --prefix ${IPADDR} ${NETMASK})
 ip addr add ${IPADDR} peer ${GATEWAY}/${PREFIX} dev ${DEVICE}
-ip link set up dev ${DEVICE}
+set_link_up ${DEVICE}
 # Wait for the device to come up - the chandev'ified ctc driver can take
 # quite a while...
 timeout=0

--- a/sysconfig/network-scripts/ifup-eth
+++ b/sysconfig/network-scripts/ifup-eth
@@ -154,7 +154,7 @@ fi
 # so it can actually get an IP.
 if [ "$ISALIAS" = no ] && is_bonding_device ${DEVICE} ; then
     install_bonding_driver ${DEVICE}
-    /sbin/ip link set dev ${DEVICE} up
+    set_link_up ${DEVICE}
     for device in $(LANG=C grep -l "^[[:space:]]*MASTER=['\"]\?${DEVICE}['\"]\?\([[:space:]#]\|$\)" /etc/sysconfig/network-scripts/ifcfg-*) ; do
         is_ignored_file "$device" && continue
         /sbin/ifup ${device##*/} || net_log "Unable to start slave device ${device##*/} for master ${DEVICE}." warning
@@ -178,7 +178,7 @@ if [ -n "${BRIDGE}" ] && [ -x /usr/sbin/brctl ]; then
         /usr/sbin/brctl addbr -- ${BRIDGE} 2>/dev/null
     fi
     /sbin/ip addr flush dev ${DEVICE} 2>/dev/null
-    /sbin/ip link set dev ${DEVICE} up
+    set_link_up ${DEVICE}
     ethtool_set
     [ -n "${LINKDELAY}" ] && /bin/sleep ${LINKDELAY}
     /usr/sbin/brctl addif -- ${BRIDGE} ${DEVICE}
@@ -233,7 +233,7 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
 else 
     if [ -z "${IPADDR}" -a -z "${IPADDR0}" -a -z "${IPADDR1}" -a -z "${IPADDR2}" ]; then
         # enable device without IP, useful for e.g. PPPoE
-        ip link set dev ${REALDEVICE} up
+        set_link_up ${REALDEVICE}
         ethtool_set
         [ -n "${LINKDELAY}" ] && /bin/sleep ${LINKDELAY}
     else
@@ -243,7 +243,7 @@ else
         [ -n "${ARP}" ] && \
             ip link set dev ${REALDEVICE} $(toggle_value arp $ARP)
 
-        if ! ip link set dev ${REALDEVICE} up ; then
+        if ! set_link_up ${REALDEVICE} ; then
             net_log $"Failed to bring up ${DEVICE}."
             exit 1
         fi

--- a/sysconfig/network-scripts/ifup-ippp
+++ b/sysconfig/network-scripts/ifup-ippp
@@ -342,7 +342,7 @@ function addprovider()
     # activate ISDN device
     /usr/bin/logger -p daemon.info -t ifup-ippp "ip addr add $IPADDR peer $GATEWAY${pfx:/$pfx} dev $DEVICE"
     ip addr add $IPADDR peer $GATEWAY${pfx:/$pfx} dev $DEVICE
-    ip link set dev $DEVICE up
+    set_link_up $DEVICE
 
     if [ "$ENCAP" = "syncppp" ]; then
         # start ipppd daemon

--- a/sysconfig/network-scripts/ifup-plip
+++ b/sysconfig/network-scripts/ifup-plip
@@ -12,7 +12,7 @@ fi
 
 [ -z "$PREFIX" ] && eval $(/bin/ipcalc --prefix ${IPADDR} ${NETMASK})
 ip addr add ${IPADDR} peer ${REMIP}/${PREFIX} dev ${DEVICE}
-ip link set up dev ${DEVICE}
+set_link_up ${DEVICE}
 ip route add ${NETWORK} dev ${DEVICE}
 
 . /etc/sysconfig/network

--- a/sysconfig/network-scripts/ifup-plusb
+++ b/sysconfig/network-scripts/ifup-plusb
@@ -29,7 +29,7 @@ if [ ${BROADCAST} != ""  ]  ; then
 else
     ip addr add ${IPADDR} peer ${REMIP}/${PREFIX} dev ${DEVICE}
 fi
-ip link set up dev ${DEVICE}
+set_link_up ${DEVICE}
 
 . /etc/sysconfig/network
 

--- a/sysconfig/network-scripts/ifup-tunnel
+++ b/sysconfig/network-scripts/ifup-tunnel
@@ -86,7 +86,7 @@ fi
 /sbin/ip addr add "$MY_INNER_IPADDR" dev "$DEVICE" \
     ${PEER_INNER_IPADDR:+peer "$PEER_INNER_IPADDR"}
 
-/sbin/ip link set dev "$DEVICE" up
+set_link_up $DEVICE
 
 # IPv6 initialisation?
 /etc/sysconfig/network-scripts/ifup-ipv6 ${CONFIG}

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -468,11 +468,14 @@ check_device_down ()
     fi
 }
 
+set_link_up ()
+{
+    [ "$LINKSTATUS" = down ] || grep -qsx 1 /sys/class/net/$1/carrier && ip link set dev $1 up >/dev/null 2>&1
+}
+
 check_link_down ()
 {
-    if ! LC_ALL=C ip link show dev $1 2>/dev/null| grep -q ",UP" ; then
-        ip link set dev $1 up >/dev/null 2>&1
-    fi
+    set_link_up $1
     timeout=0
     delay=10
     [ -n "$LINKDELAY" ] && delay=$(($LINKDELAY * 2))

--- a/sysconfig/network-scripts/network-functions-ipv6
+++ b/sysconfig/network-scripts/network-functions-ipv6
@@ -10,6 +10,10 @@
 #
 #
 
+set_link_up ()
+{
+    [ "$LINKSTATUS" = down ] || grep -qsx 1 /sys/class/net/$1/carrier && ip link set dev $1 up >/dev/null 2>&1
+}
 
 ##### Test for IPv6 capabilities
 # $1: (optional) testflag: currently supported: "testonly" (do not load a module)
@@ -108,7 +112,7 @@ ipv6_enable_autotunnel() {
         true
     else
         # bring up basic tunnel device
-        /sbin/ip link set sit0 up
+        set_link_up sit0
 
             if ! ipv6_test_device_status sit0; then
                 net_log $"Tunnel device 'sit0' enabling didn't work" err $fn
@@ -159,7 +163,7 @@ ipv6_add_addr_on_device() {
         net_log $"Device '$device' doesn't exist" err $fn
         return 3
     else
-        /sbin/ip link set $device up
+        set_link_up $device
 
             if ! ipv6_test_device_status $device; then
                 net_log $"Device '$device' enabling didn't work" err $fn
@@ -604,7 +608,7 @@ ipv6_add_tunnel_device() {
             return 3
         fi
 
-        /sbin/ip link set $device up
+        set_link_up $device
 
         if ! ipv6_test_device_status $device; then
             net_log $"Tunnel device '$device' bringing up didn't work" err $fn


### PR DESCRIPTION
Some interfaces like Open vSwitch bridges using the userspace datapath,
needs the link to be kept down to avoid issues.
Add a LINKSTATUS=[down|up] ifcfg parameter to add this functionality.
If not specified, the link will default to up as before.

Signed-off-by: Matteo Croce <mcroce@redhat.com>