### PR TITLE
RHEL-7 | network.service: 'reload' removed

### DIFF
--- a/rc.d/init.d/network
+++ b/rc.d/init.d/network
@@ -236,14 +236,14 @@ status)
     echo $"Currently active devices:"
     echo $(/sbin/ip -o link show up | awk -F ": " '{ print $2 }')
     ;;
-restart|reload|force-reload)
+restart|force-reload)
     cd "$CWD"
     $0 stop
     $0 start
     rc=$?
     ;;
 *)
-    echo $"Usage: $0 {start|stop|status|restart|reload|force-reload}"
+    echo $"Usage: $0 {start|stop|status|restart|force-reload}"
     exit 2
 esac
 


### PR DESCRIPTION
More info: https://bugzilla.redhat.com/show_bug.cgi?id=1554690