### PR TITLE
RHEL-6 | cryptsetup: do not forward STDERR to /dev/null when promting for passphrase

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -2,7 +2,7 @@
 
 Summary: The inittab file and the /etc/init.d scripts
 Name: initscripts
-Version: 9.03.59
+Version: 9.03.60
 # ppp-watch is GPLv2+, everything else is GPLv2
 License: GPLv2 and GPLv2+
 Group: System Environment/Base
@@ -248,6 +248,9 @@ rm -rf $RPM_BUILD_ROOT
 /etc/profile.d/debug*
 
 %changelog
+* Thu Apr 26 2018 David Kaspar [Dee'Kej] <dkaspar@redhat.com> - 9.03.60-1
+- cryptsetup: do not forward STDERR to /dev/null when promting for passphrase
+
 * Tue Feb 13 2018 David Kaspar [Dee'Kej] <dkaspar@redhat.com> - 9.03.59-1
 - init.d/network: start vpninterfaces
 - ARPUPDATE option introduced

--- a/rc.d/init.d/functions
+++ b/rc.d/init.d/functions
@@ -952,7 +952,7 @@ init_crypto() {
 	    fi
 	else
 	    [ -z "$key" ] && plymouth --hide-splash
-	    /sbin/cryptsetup $params ${key:+-d $key} create "$dst" "$src" <&1 2>/dev/null && success || failure
+	    /sbin/cryptsetup $params ${key:+-d $key} create "$dst" "$src" <&1 && success || failure
 	    rc=$?
 	    [ -z "$key" ] && plymouth --show-splash
 	fi


### PR DESCRIPTION
More info: https://bugzilla.redhat.com/show_bug.cgi?id=1571035