### PR TITLE
fix is_hostname_set wrong return value

### DIFF
--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -384,11 +384,11 @@ is_hostname_set ()
     case "${HOSTNAME}" in
         '(none)' | 'localhost' | 'localhost.localdomain')
             # Hostname NOT set:
-            return 1
+            return 0
             ;;
         *)
             # Hostname IS set:
-            return 0
+            return 1
             ;;
     esac
 }


### PR DESCRIPTION
is_hostname_set should return 1 when hostname is set, return 0 when hostname is not set.