### PR TITLE
RHEL-7 | sysctl.conf.s390: drop SHMALL and SHMMAX

### DIFF
--- a/sysctl.conf.s390
+++ b/sysctl.conf.s390
@@ -15,9 +15,3 @@ kernel.sched_min_granularity_ns = 10000000
 kernel.sched_wakeup_granularity_ns = 15000000
 kernel.sched_tunable_scaling = 0
 kernel.sched_latency_ns = 80000000
-
-# Controls the maximum shared segment size, in bytes
-kernel.shmmax = 4294967295
-
-# Controls the maximum number of shared memory segments, in pages
-kernel.shmall = 268435456


### PR DESCRIPTION
They have sane default values in kernel for IBM machines as well:
https://bugzilla.redhat.com/show_bug.cgi?id=1493069