### PR TITLE
RHEL-7 | network-functions: add error messages for bonding installation

### DIFF
--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -550,6 +550,8 @@ bond_master_exists ()
 
 install_bonding_driver ()
 {
+    local fn="install_bonding_driver"
+
     if ! bond_master_exists ${1}; then
         modprobe bonding || return 1
         echo "+$1" > /sys/class/net/bonding_masters 2>/dev/null
@@ -574,11 +576,15 @@ install_bonding_driver ()
                 value=${bopts_vals[$idx]}
 
                 if [ "${key}" = "mode" ] ; then
-                    echo "${value}" > /sys/class/net/${DEVICE}/bonding/$key
+                    echo "${value}" > /sys/class/net/${DEVICE}/bonding/$key || {
+                        net_log $"Failed to set value '$value' [mode] to ${DEVICE} bonding device" err $fn
+                    }
                     bopts_keys[$idx]=""
                 fi
                 if [ "${key}" = "miimon" ] ; then
-                    echo "${value}" > /sys/class/net/${DEVICE}/bonding/$key
+                    echo "${value}" > /sys/class/net/${DEVICE}/bonding/$key || {
+                        net_log $"Failed to set value '$value' [miimon] to ${DEVICE} bonding device" err $fn
+                    }
                     bopts_keys[$idx]=""
                 fi
             done
@@ -596,16 +602,22 @@ install_bonding_driver ()
                     IFS=',';
                     for arp_ip in $value; do
                         if ! grep -q $arp_ip /sys/class/net/${DEVICE}/bonding/$key; then
-                            echo +$arp_ip > /sys/class/net/${DEVICE}/bonding/$key
+                            echo +$arp_ip > /sys/class/net/${DEVICE}/bonding/$key || {
+                                net_log $"Failed to set '$arp_ip' value [arp_ip_target] to ${DEVICE} bonding device" err $fn
+                            }
                         fi
                     done
                     IFS=$OLDIFS;
                 elif [ "${key}" = "arp_ip_target" ]; then
                     if ! grep -q ${value#+} /sys/class/net/${DEVICE}/bonding/$key; then
-                        echo "$value" > /sys/class/net/${DEVICE}/bonding/$key
+                        echo "$value" > /sys/class/net/${DEVICE}/bonding/$key || {
+                            net_log $"Failed to set '$value' value [arp_ip_target] to ${DEVICE} bonding device" err $fn
+                        }
                     fi
                 elif [ "${key}" != "primary" ]; then
-                    echo $value > /sys/class/net/${DEVICE}/bonding/$key
+                    echo $value > /sys/class/net/${DEVICE}/bonding/$key || {
+                        net_log $"Failed to set '$value' value [$key] to ${DEVICE} bonding device" err $fn
+                    }
                 fi
             done
         fi


### PR DESCRIPTION
Same as #183. This has been requested by our customer:
https://bugzilla.redhat.com/show_bug.cgi?id=1542514