### PR TITLE
sysconfig/readonly-root: Clarify the usage of readonly-root.

### DIFF
--- a/sysconfig/readonly-root
+++ b/sysconfig/readonly-root
@@ -1,4 +1,6 @@
 # Set to 'yes' to mount the system filesystems read-only.
+# NOTE: It's necessary to append 'ro' to mount options of '/' mount point in
+#       /etc/fstab as well, otherwise the READONLY option will not work.
 READONLY=no
 # Set to 'yes' to mount various temporary state as either tmpfs
 # or on the block device labelled RW_LABEL. Implied by READONLY


### PR DESCRIPTION
Without appending the `ro` to mount options of `/` mount point the system will be still mounted as read-write, even when `READONLY=yes`.