### PR TITLE
netconsole: LSB header added

### DIFF
--- a/rc.d/init.d/netconsole
+++ b/rc.d/init.d/netconsole
@@ -6,6 +6,13 @@
 # description: Initializes network console logging
 # config: /etc/sysconfig/netconsole
 #
+### BEGIN INIT INFO
+# Provides:          netconsole
+# Required-Start:    $network
+# Short-Description: Initializes network console logging
+# Description:       Initializes network console logging of kernel messages.
+### END INIT INFO
+
 # Copyright 2002 Red Hat, Inc.
 #
 # Based in part on a shell script by


### PR DESCRIPTION
Since we are using systemd, the Default-Start/Stop keywords were omitted. Basically the LSB header is quite similar to LSB header of network service...