### PR TITLE
RHEL-7 | rhel-autorelabel: set UEFI BootNext == BootCurrent

### DIFF
--- a/systemd/rhel-autorelabel
+++ b/systemd/rhel-autorelabel
@@ -5,6 +5,30 @@
 
 . /etc/init.d/functions
 
+# If the user has this (or similar) UEFI boot order:
+#
+#             Windows | grub | Linux
+#
+# And decides to boot into grub/Linux, then the reboot at the end of autorelabel
+# would cause the system to boot into Windows again, if the autorelabel was run.
+#
+# This function restores the UEFI boot order, so the user will boot into the
+# previously set (and expected) partition.
+efi_set_boot_next() {
+    # NOTE: The [ -x /usr/sbin/efibootmgr ] test is not sufficent -- it could
+    #       succeed even on system which is not EFI-enabled...
+    if ! efibootmgr > /dev/null 2>&1; then
+        return
+    fi
+
+    # NOTE: It it possible that some other services might be setting the
+    #       'BootNext' item for any reasons, and we shouldn't override it if so.
+    if ! efibootmgr | grep --quiet -e 'BootNext'; then
+        CURRENT_BOOT="$(efibootmgr | grep -e 'BootCurrent' | sed -re 's/(^.+:[[:space:]]*)([[:xdigit:]]+)/\2/')"
+        efibootmgr -n "${CURRENT_BOOT}" > /dev/null 2>&1
+    fi
+}
+
 relabel_selinux() {
     # if /sbin/init is not labeled correctly this process is running in the
     # wrong context, so a reboot will be required after relabel
@@ -31,8 +55,10 @@ relabel_selinux() {
         [ -x "/usr/sbin/quotaoff" ] && /usr/sbin/quotaoff -aug
 	/sbin/fixfiles $FORCE restore > /dev/null 2>&1
     fi
+
     rm -f  /.autorelabel
     /usr/lib/dracut/dracut-initramfs-restore
+    efi_set_boot_next
     sync
     systemctl --force reboot
 }


### PR DESCRIPTION
In some circumstances the system could be started into UEFI shell instead of RHEL after the rhel-autorelabel has run... This commit should fix this behaviour.