### PR TITLE
RHEL-7 | network-functions: use tr to upper case strings rather than awk

### DIFF
--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -16,7 +16,7 @@ HOSTNAME="$(hostname)"
 get_hwaddr ()
 {
     if [ -f /sys/class/net/${1}/address ]; then
-        awk '{ print toupper($0) }' < /sys/class/net/${1}/address
+        tr '[a-z]' '[A-Z]' < /sys/class/net/${1}/address
     elif [ -d "/sys/class/net/${1}" ]; then
         LC_ALL= LANG= ip -o link show ${1} 2>/dev/null | \
             awk '{ print toupper(gensub(/.*link\/[^ ]* ([[:alnum:]:]*).*/,
@@ -160,10 +160,10 @@ source_config ()
         ;;
     esac
     if [ -n "$HWADDR" ]; then
-        HWADDR=$(echo $HWADDR | awk '{ print toupper($0) }')
+        HWADDR=$(tr '[a-z]' '[A-Z]' <<<"$HWADDR")
     fi
     if [ -n "$MACADDR" ]; then
-        MACADDR=$(echo $MACADDR | awk '{ print toupper($0) }')
+        MACADDR=$(tr '[a-z]' '[A-Z]' <<<"$MACADDR")
     fi
     [ -z "$DEVICE" -a -n "$HWADDR" ] && DEVICE=$(get_device_by_hwaddr $HWADDR)
     [ -z "$DEVICETYPE" ] && DEVICETYPE=$(echo ${DEVICE} | sed "s/[0-9]*$//")


### PR DESCRIPTION
Backport of PR #176.

--------------------

network-functions uses awk to tranform the mac address to upper case.
Replace awk with tr which is two order of magnitude faster:

    $ time awk '{ print toupper($0) }' </usr/share/dict/words >/dev/null

    real    0m0,227s
    user    0m0,224s
    sys     0m0,004s
    $ time tr '[a-z]' '[A-Z]' </usr/share/dict/words >/dev/null

    real    0m0,005s
    user    0m0,000s
    sys     0m0,005s

Also use here-strings instead of spawning a subshell and a pipe.

Signed-off-by: Matteo Croce <mcroce@redhat.com>