### PR TITLE
ifup/ifdown: use alternatives system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,9 @@ install:
 	mkdir -p $(ROOT)/etc/sysconfig/modules
 	mkdir -p $(ROOT)/etc/sysconfig/console
 
-	mv $(ROOT)/etc/sysconfig/network-scripts/ifup $(ROOT)/usr/sbin
-	mv $(ROOT)/etc/sysconfig/network-scripts/ifdown $(ROOT)/usr/sbin
 	(cd $(ROOT)/etc/sysconfig/network-scripts; \
 	  ln -sf ifup-ippp ifup-isdn ; \
-	  ln -sf ifdown-ippp ifdown-isdn ; \
-	  ln -sf ../../../usr/sbin/ifup . ; \
-	  ln -sf ../../../usr/sbin/ifdown . )
+	  ln -sf ifdown-ippp ifdown-isdn )
 	make install ROOT=$(ROOT) mandir=$(mandir) -C src
 	make install PREFIX=$(ROOT) -C po
 


### PR DESCRIPTION
This installs the real scripts into /etc/sysconfig/network-scripts while
leaving the management of the launchers in /usr/sbin to the alternatives
systemd.

This allows coexistence with alternative implementations of ifup and
ifdown, notably NetworkManager.

A priority of 90 is chosen rather arbitrarily, NetworkManager will use a
lower one (50) so that our implementation takes precedence over
NetworkManaager in case both are installed. In an unlikely event the
user will want to switch to NetworkManager implementation when both are
installed they can override the default with:

`update-alternatives --config ifup`