### PR TITLE
fedora-readonly: command substitution warning fixed (null-byte input)

### DIFF
--- a/systemd/fedora-readonly
+++ b/systemd/fedora-readonly
@@ -11,7 +11,7 @@ HOSTNAME="$(hostname)"
 
 # Check SELinux status
 SELINUX_STATE=
-if [ -e "/sys/fs/selinux/enforce" ] && [ "$(cat /proc/self/attr/current)" != "kernel" ]; then
+if [ -e "/sys/fs/selinux/enforce" ] && [ "$(cat /proc/self/attr/current | tr -d '\000' )" != "kernel" ]; then
 	if [ -r "/sys/fs/selinux/enforce" ] ; then
 		SELINUX_STATE=$(cat "/sys/fs/selinux/enforce")
 	else


### PR DESCRIPTION
Due to some change in bash-4.4, it started to give out warnings about ignored null-byte characters in the command substitution:

https://bugzilla.redhat.com/show_bug.cgi?id=1472137#c2