### PR TITLE
[RHEL-7] network: add knob to optionally keep interfaces up during shutdown

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -1,6 +1,6 @@
 Summary: The inittab file and the /etc/init.d scripts
 Name: initscripts
-Version: 9.49.42
+Version: 9.49.43
 # ppp-watch is GPLv2+, everything else is GPLv2
 License: GPLv2 and GPLv2+
 Group: System Environment/Base
@@ -220,6 +220,9 @@ rm -rf $RPM_BUILD_ROOT
 /etc/profile.d/debug*
 
 %changelog
+* Tue May 29 2018 David Kaspar [Dee'Kej] <dkaspar@redhat.com> - 9.49.43-1
+- network: add knob to optionally keep interfaces up during shutdown
+
 * Fri May 25 2018 David Kaspar [Dee'Kej] <dkaspar@redhat.com> - 9.49.42-1
 - rhel-autorelabel: set UEFI boot order (BootNext) same as BootCurrent
 - network-functions: use tr to upper case strings rather than awk

--- a/rc.d/init.d/network
+++ b/rc.d/init.d/network
@@ -167,6 +167,15 @@ stop)
         exit 1
     fi
 
+    # Don't shut the network down when shutting down the system if configured
+    # as such in sysconfig
+    if is_false "$IFDOWN_ON_SHUTDOWN"; then
+      if systemctl is-system-running | grep -q 'stopping'; then
+        net_log $"system is shutting down, leaving interfaces up as requested"
+        exit 1
+      fi
+    fi
+
     vlaninterfaces=""
     vpninterfaces=""
     xdslinterfaces=""

--- a/sysconfig.txt
+++ b/sysconfig.txt
@@ -178,6 +178,11 @@ Generic options:
     network has spanning tree running and must wait for STP convergence.
     Default: 0 (no delay)
 
+  IFDOWN_ON_SHUTDOWN=yes|no
+    If yes, do bring interfaces down during system shutdown. If no, leave them
+    in their current state (this is only supported on hosts using systemd).
+    Default: yes (bring interfaces down)
+
 
   IPV6FORWARDING=yes|no
     Enable or disable global forwarding of incoming IPv6 packets 


### PR DESCRIPTION
Backport of this change to RHEL-7 as well. This option is not used by default.

* network: add knob to optionally keep interfaces up during shutdown