### PR TITLE
specfile: fix failing build because of incorrect use of %{_isa}

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -133,7 +133,7 @@ service.
 
 %package -n netconsole-service
 Summary:          Service for initializing of network console logging
-Requires:         %{name}%{?_isa} = %{version}-%{release}
+Requires:         %{name} = %{version}-%{release}
 BuildArch:        noarch
 
 %shared_requirements
@@ -156,7 +156,7 @@ allows logging of kernel messages over the network.
 
 %package -n readonly-root
 Summary:          Service for configuring read-only root support
-Requires:         %{name}%{?_isa} = %{version}-%{release}
+Requires:         %{name} = %{version}-%{release}
 BuildArch:        noarch
 
 %shared_requirements


### PR DESCRIPTION
The leftover `%{_isa}` was causing the Koji build to fail:
https://koji.fedoraproject.org/koji/taskinfo?taskID=27631523