### PR TITLE
Move the /etc/rwtab.d & /etc/statetab.d folders to 'filesystem'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,6 @@ install-man: install-usr
 # Initscripts still ship some empty directories necessary for system to function
 # correctly...
 install-post: install-etc
-	install -m 0755 -d $(DESTDIR)$(sysconfdir)/rwtab.d
-	install -m 0755 -d $(DESTDIR)$(sysconfdir)/statetab.d
 	install -m 0755 -d $(DESTDIR)$(sysconfdir)/sysconfig/console
 	install -m 0755 -d $(DESTDIR)$(sysconfdir)/sysconfig/modules
 	install -m 0755 -d $(DESTDIR)$(sharedstatedir)/stateless/state

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -332,8 +332,6 @@ fi
 # ---------------
 
 %files -n readonly-root
-%dir %{_sysconfdir}/rwtab.d
-%dir %{_sysconfdir}/statetab.d
 %dir %{_sharedstatedir}/stateless
 %dir %{_sharedstatedir}/stateless/state
 %dir %{_sharedstatedir}/stateless/writable


### PR DESCRIPTION
This will allow services to install drop-in files into these folders for the 'readonly-root' service, but that service won't have to be installed by default as a result...

NOTE: We have to wait until the https://pagure.io/filesystem/pull-request/1 is merged, before we can merge the change in initscripts.