### PR TITLE
[RHEL-7] ifdown-eth: no longer needed 'pidof -x dhclient' condition removed

### DIFF
--- a/sysconfig/network-scripts/ifdown-eth
+++ b/sysconfig/network-scripts/ifdown-eth
@@ -86,7 +86,7 @@ fi
 /etc/sysconfig/network-scripts/ifdown-ipv6 ${CONFIG}
 
 retcode=0
-[ -n "$(pidof -x dhclient)" ] && {
+
 for VER in "" 6 ; do
     if [ -f "/var/run/dhclient$VER-${DEVICE}.pid" ]; then
         dhcpid=$(cat /var/run/dhclient$VER-${DEVICE}.pid)
@@ -105,7 +105,7 @@ for VER in "" 6 ; do
         fi  
     fi
 done
-}  
+
 # we can't just delete the configured address because that address
 # may have been changed in the config file since the device was
 # brought up.  Flush all addresses associated with this


### PR DESCRIPTION
This is backport to RHEL-7.

> Previously, there were 2 additional conditions related to this part of code, but they were removed in time, so this last condition has remained an artifact and is de-facto obsolete.
>
> However, the 'pidof -x dhclient' condition could cause the network service to hang on stop/restart when processes were executed from a network share... Removing that condition should hypothetically fix it.