### PR TITLE
network-scripts: forward_delay should be converted to integer

### DIFF
--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -87,6 +87,7 @@ if [ "${TYPE}" = "Bridge" ]; then
           # to obtain an IP address from DHCP.
           forward_delay="$(cat /sys/devices/virtual/net/${DEVICE}/bridge/forward_delay)"
           forward_delay="$(convert2sec ${forward_delay} centi)"
+          forward_delay=$(awk "BEGIN {printf \"%.0f\", ${forward_delay} + 0.5}")
         fi
 
         forward_delay=$(expr ${forward_delay} \* 2 + 7)


### PR DESCRIPTION
On RHEL7.5, if `STP` is enabled on a bridge but `DELAY` is not specified,
`ifup $DEVICE` will show the following error message:

```
expr: non-integer argument
/etc/sysconfig/network-scripts/ifup-eth: line 91: [: 0: unary operator
expected
```

This is because if `DELAY` is not set by the user,
`ifup-eth` will try to obtain the forward_delay value from kernel as the
value of `DELAY`.
However, the return value of `convert2sec` is a decimal, while `expr`
expects an integer for calculation.

To solve this issue, we need to round it upwards to the nearest integer.