### PR TITLE
ifup-eth: use 'bc' instead of 'expr' when computing $forward_delay

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -94,6 +94,7 @@ Requires:         %{name}%{?_isa} = %{version}-%{release}
 
 %shared_requirements
 
+Requires:         bc
 Requires:         dbus
 Requires:         gawk
 Requires:         grep

--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -89,9 +89,11 @@ if [ "${TYPE}" = "Bridge" ]; then
           forward_delay="$(convert2sec ${forward_delay} centi)"
         fi
 
-        forward_delay=$(expr ${forward_delay} \* 2 + 7)
+        forward_delay=$(bc -q <<< "${forward_delay} * 2 + 7")
 
-        [ 0$LINKDELAY -lt $forward_delay ] && LINKDELAY=$forward_delay
+        # It's possible we are comparing floating point numbers here, therefore
+        # we are using 'bc' for comparison. The [ ] and [[ ]] do not work.
+        (( $(bc -l <<< "${LINKDELAY:-0} < ${forward_delay}") )) && LINKDELAY=${forward_delay}
 
         unset forward_delay
     fi


### PR DESCRIPTION
Because the return value of `convert2sec()` function can sometimes be decimal, the follow up `expr` call can fail, since `expr` does not support floating point calculations. This can sometimes lead to error:

```shell
expr: non-integer argument
/etc/sysconfig/network-scripts/ifup-eth: line 91: [: 0: unary operator expected
```

To solve this bug, we switch to `bc` utility, which supports floating point computations. Using `bc` should also be much faster than calling `gawk` to do this.

Resolves: #227 