### PR TITLE
[RHEL8] network/ifup/ifdown: deprecation warnings for 'network-scripts' added

### DIFF
--- a/etc/rc.d/init.d/network
+++ b/etc/rc.d/init.d/network
@@ -49,6 +49,13 @@ interfaces=$(ls ifcfg-* | \
         LC_ALL=C sed 's/ //')
 rc=0
 
+net_log $"You are using 'network' service provided by 'network-scripts', which are now deprecated." warning network
+net_log $"'network-scripts' will be removed in one of the next major releases of RHEL." warning network
+net_log $"It is advised to switch to 'NetworkManager' instead for network management." warning network
+
+# This disables additional warnings during the boot process:
+export DEPRECATION_WARNING_ISSUED='true'
+
 # See how we were called.
 case "$1" in
 start)

--- a/network-scripts/ifdown
+++ b/network-scripts/ifdown
@@ -16,6 +16,12 @@ CONFIG=$1
     exit 1
 }
 
+if ! is_true ${DEPRECATION_WARNING_ISSUED}; then
+    net_log $"You are using 'ifdown' script provided by 'network-scripts', which are now deprecated." warning ifdown
+    net_log $"'network-scripts' will be removed in one of the next major releases of RHEL." warning ifdown
+    net_log $"It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well." warning ifdown
+fi
+
 need_config "${CONFIG}"
 
 [ -f "$CONFIG" ] || {

--- a/network-scripts/ifup
+++ b/network-scripts/ifup
@@ -31,6 +31,12 @@ CONFIG=${1}
     exit 1
 }
 
+if ! is_true ${DEPRECATION_WARNING_ISSUED}; then
+    net_log $"You are using 'ifup' script provided by 'network-scripts', which are now deprecated." warning ifup
+    net_log $"'network-scripts' will be removed in one of the next major releases of RHEL." warning ifup
+    net_log $"It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well." warning ifup
+fi
+
 need_config "${CONFIG}"
 
 [ -f "${CONFIG}" ] || {


### PR DESCRIPTION
In case of 'network' service these warnings are displayed only once, to not spam unnecessarily user's journalctl if they have many NICs.