### PR TITLE
[Makefile] fixes for 'release-commit' and 'tag'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,6 @@ release-commit:
 	@rm -f .changelog.tmp
 	@git add initscripts.spec
 	@git commit --message="$(NEXT_VERSION)"
-	@git tag -a -f -m "Tag as $(NEXT_VERSION)" $(NEXT_VERSION)
 	@echo -e "\n       New release commit ($(NEXT_VERSION)) created:\n"
 	@git show
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ clean:
 	@find . -name "*~" -exec rm -v -f {} \;
 
 tag:
-	@git tag -a -f -m "Tag as $(VERSION)" $(VERSION)
+	@git tag -a -f -m "$(VERSION) release" $(VERSION)
 	@echo "Tagged as $(VERSION)"
 
 release-commit:


### PR DESCRIPTION
This PR will change the message created for future tags, and tag won't be automatically be created when issuing `make release-commit`.