### PR TITLE
[RHEL-8] fixes for 'release-commit' and 'tag'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,6 @@ release-commit:
 	@rm -f .changelog.tmp
 	@git add initscripts.spec
 	@git commit --message="$(NEXT_VERSION)"
-	@git tag -a -f -m "Tag as $(NEXT_VERSION)" $(NEXT_VERSION)
 	@echo -e "\n       New release commit ($(NEXT_VERSION)) created:\n"
 	@git show
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ clean:
 	@find . -name "*~" -exec rm -v -f {} \;
 
 tag:
-	@git tag -a -f -m "Tag as $(VERSION)" $(VERSION)
+	@git tag -a -f -m "$(VERSION) release" $(VERSION)
 	@echo "Tagged as $(VERSION)"
 
 release-commit:

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ sysconfdir     = /etc
 localstatedir  = /var
 sharedstatedir = $(localstatedir)/lib
 
-VERSION       := $(shell gawk '/Version:/ { print $$2 }' initscripts.spec)
-NEXT_VERSION  := $(shell gawk '/Version:/ { print $$2 + 0.01}' initscripts.spec)
-
+VERSION         := $(shell gawk '/Version:/ { print $$2 }' initscripts.spec)
+NEXT_VERSION_XY := $(shell sed -re 's/([[:digit:]]+\.[[:digit:]]+)(.*)/\1/' <<< "$(VERSION)")
+NEXT_VERSION_Z  := $(shell sed -re 's/([[:digit:]]+\.[[:digit:]]+\.)(.*)/\2 + 1/' <<< "$(VERSION)" | bc)
+NEXT_VERSION    := $(NEXT_VERSION_XY).$(NEXT_VERSION_Z)
 
 all: make-binaries make-translations
 


### PR DESCRIPTION
This is a backport of #236 to RHEL8.

It also fixes the incrementing for `Version` in specfile when using `make release-commit`, which was broken before.