### PR TITLE
ifup-post: fix incorrect condition for RESOLV_MODS

### DIFF
--- a/network-scripts/ifup-post
+++ b/network-scripts/ifup-post
@@ -28,7 +28,7 @@ if ! is_true "$NOROUTESET"; then
 fi
 
 
-if ! is_false "${PEERDNS}" || ! is_false "${RESOLV_MODS}"; then
+if ! is_false "${PEERDNS}" || is_true "${RESOLV_MODS}"; then
     # Obtain the DNS entries when using PPP if necessary:
     [ -n "${MS_DNS1}" ] && DNS1="${MS_DNS1}"
     [ -n "${MS_DNS2}" ] && DNS2="${MS_DNS2}"


### PR DESCRIPTION
Before the commit 5d6156454bf8 we were not updating the `/etc/resolv.conf` file if the `RESOLV_MODS` was empty...

**BEFORE (correct behaviour):**

```bash
if ! is_false "$PEERDNS" || [ -n "$RESOLV_MODS" ] && ! is_false "$RESOLV_MODS"; then
```

**NOW (bad behaviour):**
```bash
if ! is_false "${PEERDNS}" || ! is_false "${RESOLV_MODS}"; then
```
This is causing the `/etc/resolv.conf` file to be always updated when `RESOLV_MODS` is not set... By using `is_true "${RESOLV_MODS}"` we achieve the same behaviour as before (correct).

See https://bugzilla.redhat.com/show_bug.cgi?id=1610411 for more info.