### PR TITLE
ifup-eth: apply PERSISTENT_DHCLIENT to IPv6 dhclient daemon

### DIFF
--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -360,7 +360,13 @@ if is_true "${DHCPV6C}" && [ -x /sbin/dhclient ]; then
     echo -n $"Determining IPv6 information for ${DEVICE}..."
 
     # Initialize the dhclient args for IPv6 and obtain the hostname options if needed:
-    DHCLIENTARGS="-6 -1 ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /run/dhclient6-${DEVICE}.pid ${DEVICE}"
+    if is_true "${PERSISTENT_DHCLIENT}"; then
+        ONESHOT="";
+    else
+        ONESHOT="-1";
+    fi;
+
+    DHCLIENTARGS="-6 ${ONESHOT} ${DHCPV6C_OPTIONS} ${DHCLIENTCONF} -lf ${LEASEFILE} -pf /run/dhclient6-${DEVICE}.pid ${DEVICE}"
     set_hostname_options DHCLIENTARGS
 
     if /sbin/dhclient $DHCLIENTARGS; then


### PR DESCRIPTION
IPv6 dhclient daemon only tries one time to obtain a IPv6 address
from a DHCPv6 server regardless of the setting of PERSISTENT_DHCLIENT.
PERSISTENT_DHCLIENT option is only used for IPv4 dhclient daemon.

With the popularization of IPv6 protocol, some users prefer setting
IPv6 like IPv4. I think there are two solutions as follows,
1. adopt PERSISTENT_DHCLIENT option to both IPv4 and IPv6.
2. create a new option, such as PERSISTENT_DHCLIENT_IPV6 option,
just for IPv6.

The first solution does not introduce addition options, and the IPv4
and IPv6 settings are consistent. So I perfer choosing the first
solution.

Fixes: bf00a0048 ("Replace /var/run with /run everywhere")
Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>