### PR TITLE
Remove remaining bashisms in /etc/rc.d/init.d/functions

### DIFF
--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -291,27 +291,14 @@ daemon() {
     # if they set NICELEVEL in /etc/sysconfig/foo, honor it
     [ -n "${NICELEVEL:-}" ] && nice="nice -n $NICELEVEL"
 
-    # if they set CGROUP_DAEMON in /etc/sysconfig/foo, honor it
-    if [ -n "${CGROUP_DAEMON}" ]; then
-        if [ ! -x /bin/cgexec ]; then
-            gettext 'Cgroups not installed'; warning
-            echo
-        else
-            cgroup="/bin/cgexec";
-            for i in $CGROUP_DAEMON; do
-                cgroup="$cgroup -g $i";
-            done
-        fi
-    fi
-
     # Echo daemon
     [ "${BOOTUP:-}" = "verbose" -a -z "${LSB:-}" ] && echo -n " $base"
 
     # And start it up.
     if [ -z "$user" ]; then
-       $cgroup $nice $shell -c "$corelimit >/dev/null 2>&1 ; $*"
+       $nice $shell -c "$corelimit >/dev/null 2>&1 ; $*"
     else
-       $cgroup $nice runuser -s $shell $user -c "$corelimit >/dev/null 2>&1 ; $*"
+       $nice runuser -s $shell $user -c "$corelimit >/dev/null 2>&1 ; $*"
     fi
 
     [ "$?" -eq 0 ] && success $(eval_gettext '$base startup') || failure $(eval_gettext '$base startup')

--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -13,6 +13,9 @@ umask 022
 PATH="/sbin:/usr/sbin:/bin:/usr/bin"
 export PATH
 
+# Enable $TEXTDOMAIN i18n
+. gettext.sh
+
 if [ $PPID -ne 1 -a -z "$SYSTEMCTL_SKIP_REDIRECT" ] && \
         [ -d /run/systemd/system ] ; then
     case "$0" in
@@ -30,16 +33,16 @@ systemctl_redirect () {
 
     case "$command" in
     start)
-        s=$"Starting $prog (via systemctl): "
+        s=$(eval_gettext 'Starting $prog (via systemctl): ')
         ;;
     stop)
-        s=$"Stopping $prog (via systemctl): "
+        s=$(eval_gettext 'Stopping $prog (via systemctl): ')
         ;;
     reload|try-reload)
-        s=$"Reloading $prog configuration (via systemctl): "
+        s=$(eval_gettext 'Reloading $prog configuration (via systemctl): ')
         ;;
     restart|try-restart|condrestart)
-        s=$"Restarting $prog (via systemctl): "
+        s=$(eval_gettext 'Restarting $prog (via systemctl): ')
         ;;
     esac
 
@@ -49,7 +52,7 @@ systemctl_redirect () {
 
     if ! systemctl show "$prog.service" > /dev/null 2>&1 || \
             systemctl show -p LoadState "$prog.service" | grep -q 'not-found' ; then
-        action $"Reloading systemd: " /bin/systemctl daemon-reload
+        action $(gettext 'Reloading systemd: ') /bin/systemctl daemon-reload
     fi
 
     action "$s" /bin/systemctl $options $command "$prog.service"
@@ -70,15 +73,15 @@ if [ -z "${BOOTUP:-}" ]; then
         # Column to start "[  OK  ]" label in:
         RES_COL=60
         # terminal sequence to move to that column:
-        MOVE_TO_COL="echo -en \\033[${RES_COL}G"
+        MOVE_TO_COL="printf \\033[%dG $RES_COL"
         # Terminal sequence to set color to a 'success' (bright green):
-        SETCOLOR_SUCCESS="echo -en \\033[1;32m"
+        SETCOLOR_SUCCESS="printf \\033[1;32m"
         # Terminal sequence to set color to a 'failure' (bright red):
-        SETCOLOR_FAILURE="echo -en \\033[1;31m"
+        SETCOLOR_FAILURE="printf \\033[1;31m"
         # Terminal sequence to set color to a 'warning' (bright yellow):
-        SETCOLOR_WARNING="echo -en \\033[1;33m"
+        SETCOLOR_WARNING="printf \\033[1;33m"
         # Terminal sequence to reset to the default color:
-        SETCOLOR_NORMAL="echo -en \\033[0;39m"
+        SETCOLOR_NORMAL="printf \\033[0;39m"
 
         # Verbosity of logging:
         LOGLEVEL=1
@@ -227,7 +230,7 @@ daemon() {
     while [ "$1" != "${1##[-+]}" ]; do
         case $1 in
         '')
-            echo $"$0: Usage: daemon [+/-nicelevel] {program}" "[arg1]..."
+            eval_gettext '$0: Usage: daemon [+/-nicelevel] {program}'; echo " [arg1]..."
             return 1
             ;;
         --check)
@@ -265,7 +268,7 @@ daemon() {
             shift
             ;;
         *)
-            echo $"$0: Usage: daemon [+/-nicelevel] {program}" "[arg1]..."
+            eval_gettext '$0: Usage: daemon [+/-nicelevel] {program}' ; echo " [arg1]..."
             return 1
             ;;
       esac
@@ -291,7 +294,7 @@ daemon() {
     # if they set CGROUP_DAEMON in /etc/sysconfig/foo, honor it
     if [ -n "${CGROUP_DAEMON}" ]; then
         if [ ! -x /bin/cgexec ]; then
-            echo -n "Cgroups not installed"; warning
+            gettext 'Cgroups not installed'; warning
             echo
         else
             cgroup="/bin/cgexec";
@@ -311,7 +314,7 @@ daemon() {
        $cgroup $nice runuser -s $shell $user -c "$corelimit >/dev/null 2>&1 ; $*"
     fi
 
-    [ "$?" -eq 0 ] && success $"$base startup" || failure $"$base startup"
+    [ "$?" -eq 0 ] && success $(eval_gettext '$base startup') || failure $(eval_gettext '$base startup')
 }
 
 # A function to stop a program.
@@ -321,7 +324,7 @@ killproc() {
     RC=0; delay=3; try=0
     # Test syntax.
     if [ "$#" -eq 0 ]; then
-        echo $"Usage: killproc [-p pidfile] [ -d delay] {program} [-signal]"
+        gettext 'Usage: killproc [-p pidfile] [ -d delay] {program} [-signal]'; echo
         return 1
     fi
     if [ "$1" = "-p" ]; then
@@ -330,8 +333,8 @@ killproc() {
     fi
     if [ "$1" = "-b" ]; then
         if [ -z $pid_file ]; then
-            echo $"-b option can be used only with -p"
-            echo $"Usage: killproc -p pidfile -b binary program"
+            gettext '-b option can be used only with -p'; echo
+            gettext 'Usage: killproc -p pidfile -b binary program'; echo
             return 1
         fi
         binary=$2
@@ -340,7 +343,7 @@ killproc() {
     if [ "$1" = "-d" ]; then
         delay=$(echo $2 | awk -v RS=' ' -v IGNORECASE=1 '{if($1!~/^[0-9.]+[smhd]?$/) exit 1;d=$1~/s$|^[0-9.]*$/?1:$1~/m$/?60:$1~/h$/?60*60:$1~/d$/?24*60*60:-1;if(d==-1) exit 1;delay+=d*$1} END {printf("%d",delay+0.5)}')
         if [ "$?" -eq 1 ]; then
-            echo $"Usage: killproc [-p pidfile] [ -d delay] {program} [-signal]"
+            gettext 'Usage: killproc [-p pidfile] [ -d delay] {program} [-signal]'; echo
             return 1
         fi
         shift 2
@@ -360,23 +363,23 @@ killproc() {
         if [ -z "$pid_file" ]; then
             pid="$(__pids_pidof "$1")"
         else
-            [ "$RC" = "4" ] && { failure $"$base shutdown" ; return $RC ;}
+            [ "$RC" = "4" ] && { failure $(eval_gettext '$base shutdown') ; return $RC ;}
         fi
     fi
 
     # Kill it.
     if [ -n "$pid" ] ; then
-        [ "$BOOTUP" = "verbose" -a -z "${LSB:-}" ] && echo -n "$base "
+        [ "$BOOTUP" = "verbose" -a -z "${LSB:-}" ] && printf '%s ' "$base"
         if [ -z "$killlevel" ] ; then
             __kill_pids_term_kill -d $delay $pid
             RC=$?
-            [ "$RC" -eq 0 ] && success $"$base shutdown" || failure $"$base shutdown"
+            [ "$RC" -eq 0 ] && success $(eval_gettext '$base shutdown') || failure $(eval_gettext '$base shutdown')
         # use specified level only
         else
             if checkpid $pid; then
                 kill $killlevel $pid >/dev/null 2>&1
                 RC=$?
-                [ "$RC" -eq 0 ] && success $"$base $killlevel" || failure $"$base $killlevel"
+                [ "$RC" -eq 0 ] && success $(eval_gettext '$base $killlevel') || failure $(eval_gettext '$base $killlevel')
             elif [ -n "${LSB:-}" ]; then
                 RC=7 # Program is not running
             fi
@@ -385,7 +388,7 @@ killproc() {
         if [ -n "${LSB:-}" -a -n "$killlevel" ]; then
             RC=7 # Program is not running
         else
-            failure $"$base shutdown"
+            failure $(eval_gettext '$base shutdown')
             RC=0
         fi
     fi
@@ -403,7 +406,7 @@ pidfileofproc() {
 
     # Test syntax.
     if [ "$#" = 0 ] ; then
-        echo $"Usage: pidfileofproc {program}"
+        gettext 'Usage: pidfileofproc {program}'; echo
         return 1
     fi
 
@@ -418,7 +421,7 @@ pidofproc() {
 
     # Test syntax.
     if [ "$#" = 0 ]; then
-        echo $"Usage: pidofproc [-p pidfile] {program}"
+        gettext 'Usage: pidofproc [-p pidfile] {program}'; echo
         return 1
     fi
     if [ "$1" = "-p" ]; then
@@ -444,7 +447,7 @@ status() {
 
     # Test syntax.
     if [ "$#" = 0 ] ; then
-        echo $"Usage: status [-p pidfile] {program}"
+        gettext 'Usage: status [-p pidfile] {program}'; echo
         return 1
     fi
     if [ "$1" = "-p" ]; then
@@ -457,8 +460,8 @@ status() {
     fi
     if [ "$1" = "-b" ]; then
         if [ -z $pid_file ]; then
-            echo $"-b option can be used only with -p"
-            echo $"Usage: status -p pidfile -b binary program"
+            gettext '-b option can be used only with -p'; echo
+            gettext 'Usage: status -p pidfile -b binary program'; echo
             return 1
         fi
         binary=$2
@@ -485,21 +488,21 @@ status() {
         pid="$(__pids_pidof "$1")"
     fi
     if [ -n "$pid" ]; then
-        echo $"${base} (pid $pid) is running..."
+        eval_gettext '${base} (pid $pid) is running...'; echo
         return 0
     fi
 
     case "$RC" in
     0)
-        echo $"${base} (pid $pid) is running..."
+        eval_gettext '${base} (pid $pid) is running...'; echo
         return 0
         ;;
     1)
-        echo $"${base} dead but pid file exists"
+        eval_gettext '${base} dead but pid file exists'; echo
         return 1
         ;;
     4)
-        echo $"${base} status unknown due to insufficient privileges."
+        eval_gettext '${base} status unknown due to insufficient privileges.'; echo
         return 4
         ;;
     esac
@@ -508,54 +511,50 @@ status() {
     fi
     # See if /var/lock/subsys/${lock_file} exists
     if [ -f /var/lock/subsys/${lock_file} ]; then
-        echo $"${base} dead but subsys locked"
+        eval_gettext '${base} dead but subsys locked'; echo
         return 2
     fi
-    echo $"${base} is stopped"
+    eval_gettext '${base} is stopped'; echo
     return 3
 }
 
 echo_success() {
     [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
-    echo -n "["
+    printf '%s' '['
     [ "$BOOTUP" = "color" ] && $SETCOLOR_SUCCESS
-    echo -n $"  OK  "
+    gettext '  OK  '
     [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
-    echo -n "]"
-    echo -ne "\r"
+    printf '%s\r' ']'
     return 0
 }
 
 echo_failure() {
     [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
-    echo -n "["
+    printf '%s' '['
     [ "$BOOTUP" = "color" ] && $SETCOLOR_FAILURE
-    echo -n $"FAILED"
+    gettext 'FAILED'
     [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
-    echo -n "]"
-    echo -ne "\r"
+    printf '%s\r' ']'
     return 1
 }
 
 echo_passed() {
     [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
-    echo -n "["
+    printf '%s' '['
     [ "$BOOTUP" = "color" ] && $SETCOLOR_WARNING
-    echo -n $"PASSED"
+    gettext 'PASSED'
     [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
-    echo -n "]"
-    echo -ne "\r"
+    printf '%s\r' ']'
     return 1
 }
 
 echo_warning() {
     [ "$BOOTUP" = "color" ] && $MOVE_TO_COL
-    echo -n "["
+    printf '%s' '['
     [ "$BOOTUP" = "color" ] && $SETCOLOR_WARNING
-    echo -n $"WARNING"
+    gettext 'WARNING'
     [ "$BOOTUP" = "color" ] && $SETCOLOR_NORMAL
-    echo -n "]"
-    echo -ne "\r"
+    printf '%s\r' ']'
     return 1
 }
 
@@ -600,9 +599,9 @@ action() {
     local STRING rc
 
     STRING=$1
-    echo -n "$STRING "
+    printf '%s ' "$STRING"
     shift
-    "$@" && success $"$STRING" || failure $"$STRING"
+    "$@" && success $(gettext "$STRING") || failure $(gettext "$STRING")
     rc=$?
     echo
     return $rc

--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -222,7 +222,7 @@ daemon() {
     # Test syntax.
     local gotbase= force= nicelevel corelimit
     local pid base= user= nice= bg= pid_file=
-    local cgroup=
+    local cgroup= shell=
     nicelevel=0
     while [ "$1" != "${1##[-+]}" ]; do
         case $1 in
@@ -282,6 +282,9 @@ daemon() {
     # make sure it doesn't core dump anywhere unless requested
     corelimit="ulimit -S -c ${DAEMON_COREFILE_LIMIT:-0}"
 
+    # if they set SERVICESHELL in /etc/sysconfig/foo, honor it
+    shell="${SERVICESHELL:-/bin/sh}"
+
     # if they set NICELEVEL in /etc/sysconfig/foo, honor it
     [ -n "${NICELEVEL:-}" ] && nice="nice -n $NICELEVEL"
 
@@ -303,9 +306,9 @@ daemon() {
 
     # And start it up.
     if [ -z "$user" ]; then
-       $cgroup $nice /bin/bash -c "$corelimit >/dev/null 2>&1 ; $*"
+       $cgroup $nice $shell -c "$corelimit >/dev/null 2>&1 ; $*"
     else
-       $cgroup $nice runuser -s /bin/bash $user -c "$corelimit >/dev/null 2>&1 ; $*"
+       $cgroup $nice runuser -s $shell $user -c "$corelimit >/dev/null 2>&1 ; $*"
     fi
 
     [ "$?" -eq 0 ] && success $"$base startup" || failure $"$base startup"

--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -111,18 +111,14 @@ __kill_pids_term_kill_checkpids() {
     local pid=
     local pids=$*
     local remaining=
-    local stat=
     local stime=
 
     for pid in $pids ; do
         [ ! -e  "/proc/$pid" ] && continue
-        read -r line < "/proc/$pid/stat" 2> /dev/null
-
-        stat=($line)
-        stime=${stat[21]}
+        stime=$(cut -d ' ' -f 22 2>/dev/null </proc/$pid/stat)
 
         [ -n "$stime" ] && [ "$base_stime" -lt "$stime" ] && continue
-        remaining+="$pid "
+        remaining="${remaining}$pid "
     done
 
     echo "$remaining"
@@ -135,13 +131,9 @@ __kill_pids_term_kill() {
     local try=0
     local delay=3;
     local pid=
-    local stat=
     local base_stime=
 
-    # We can't initialize stat & base_stime on the same line where 'local'
-    # keyword is, otherwise the sourcing of this file will fail for ksh...
-    stat=($(< /proc/self/stat))
-    base_stime=${stat[21]}
+    base_stime=$(cut -d ' ' -f 22 2>/dev/null </proc/$$/stat)
 
     if [ "$1" = "-d" ]; then
         delay=$2
@@ -163,7 +155,7 @@ __kill_pids_term_kill() {
             sleep 1
             kill_list=$(__kill_pids_term_kill_checkpids $base_stime $kill_list)
             [ -z "$kill_list" ] && break
-            let try+=1
+            try=$((try+1))
         done
         if [ -n "$kill_list" ] ; then
             kill -KILL $kill_list >/dev/null 2>&1
@@ -197,13 +189,16 @@ __pids_var_run() {
             read line
             [ -z "$line" ] && break
             for p in $line ; do
-                if [ -z "${p//[0-9]/}" ] && [ -d "/proc/$p" ] ; then
-                    if [ -n "$binary" ] ; then
-                        local b=$(readlink /proc/$p/exe | sed -e 's/\s*(deleted)$//')
-                        [ "$b" != "$binary" ] && continue
-                    fi
-                    pid="$pid $p"
-                fi
+                [ -d  "/proc/$p" ] || continue
+                case $p in
+                    [0-9][0-9]*)
+                        if [ -n "$binary" ] ; then
+                            local b=$(readlink /proc/$p/exe | sed -e 's/\s*(deleted)$//')
+                            [ "$b" != "$binary" ] && continue
+                        fi
+                        pid="$pid $p"
+                    ;;
+                esac
             done
         done < "$pid_file"
 


### PR DESCRIPTION
Replaces insecure bash $"..." constructs with gettext/eval_gettext calls
Removes hard-coded /bin/bash for sysconfig-overrideable /bin/sh in daemon()
Rewrites prior ksh loading patch to also be executable with non-bash: 
https://github.com/fedora-sysv/initscripts/commit/8cb57357a84900707d25c8f74184891122713df0