### PR TITLE
rc.d/functions: remove support cgroups

### DIFF
--- a/doc/sysconfig.txt
+++ b/doc/sysconfig.txt
@@ -3,14 +3,6 @@
 
 Generic options:
 
-/etc/sysconfig/*
-
-   CGROUP_DAEMON=
-     List of control groups that the daemon will be run in. For example,
-     CGROUP_DAEMON="cpu:daemons cpuacct:/" will run it in the daemons
-     group for the CPU controller, and the '/' group for the CPU accounting
-     controller.
-
 /etc/sysconfig/authconfig
 
   used by authconfig to store information about the system's user

--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -290,27 +290,14 @@ daemon() {
     # if they set NICELEVEL in /etc/sysconfig/foo, honor it
     [ -n "${NICELEVEL:-}" ] && nice="nice -n $NICELEVEL"
 
-    # if they set CGROUP_DAEMON in /etc/sysconfig/foo, honor it
-    if [ -n "${CGROUP_DAEMON}" ]; then
-        if [ ! -x /bin/cgexec ]; then
-            echo -n "Cgroups not installed"; warning
-            echo
-        else
-            cgroup="/bin/cgexec";
-            for i in $CGROUP_DAEMON; do
-                cgroup="$cgroup -g $i";
-            done
-        fi
-    fi
-
     # Echo daemon
     [ "${BOOTUP:-}" = "verbose" -a -z "${LSB:-}" ] && echo -n " $base"
 
     # And start it up.
     if [ -z "$user" ]; then
-       $cgroup $nice /bin/bash -c "$corelimit >/dev/null 2>&1 ; $*"
+       $nice /bin/bash -c "$corelimit >/dev/null 2>&1 ; $*"
     else
-       $cgroup $nice runuser -s /bin/bash $user -c "$corelimit >/dev/null 2>&1 ; $*"
+       $nice runuser -s /bin/bash $user -c "$corelimit >/dev/null 2>&1 ; $*"
     fi
 
     [ "$?" -eq 0 ] && success $"$base startup" || failure $"$base startup"


### PR DESCRIPTION
Now with systemd, this does not work pretty well and users really should
use systemd unit-files for this.