### PR TITLE
Replace not working awk command with sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ localstatedir  = /var
 sharedstatedir = $(localstatedir)/lib
 
 VERSION       := $(shell gawk '/Version:/ { print $$2 }' initscripts.spec)
-NEXT_VERSION  := $(shell gawk '/Version:/ { print $$2 + 0.01}' initscripts.spec)
+NEXT_VERSION  := $(shell sed -nr 's/Version:[ ]*([0-9]*)\.([0-9]*)\.([0-9]*)/echo "\1\.\2\.$$((\3+1))"/gep' initscripts.spec)
 
 
 all: make-binaries make-translations


### PR DESCRIPTION
Sed command get version number from spec file and increment last
number by one. Work like old awk command was intended to work.

Source: https://stackoverflow.com/questions/14348432/how-to-find-replace-and-increment-a-matched-number-with-sed-awk/14348899