### PR TITLE
all: source /functions from the correct location

### DIFF
--- a/etc/rc.d/init.d/network
+++ b/etc/rc.d/init.d/network
@@ -14,7 +14,7 @@
 ### END INIT INFO
 
 # Source function library.
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 if [ ! -f /etc/sysconfig/network ]; then
     exit 6

--- a/network-scripts/ifdown
+++ b/network-scripts/ifdown
@@ -2,7 +2,7 @@
 
 unset WINDOW # defined by screen, conflicts with our usage
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifdown-bnep
+++ b/network-scripts/ifdown-bnep
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifdown-eth
+++ b/network-scripts/ifdown-eth
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifdown-tunnel
+++ b/network-scripts/ifdown-tunnel
@@ -20,7 +20,7 @@
 #  - Sean Millichamp <sean@enertronllc.com>
 # for providing the scripts this one is based on
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifup
+++ b/network-scripts/ifup
@@ -17,7 +17,7 @@
 
 unset WINDOW # defined by screen, conflicts with our usage
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifup-bnep
+++ b/network-scripts/ifup-bnep
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifup-ippp
+++ b/network-scripts/ifup-ippp
@@ -4,7 +4,7 @@
 # 
 # This script is normally called from the ifup script when it detects an ippp device.
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifup-post
+++ b/network-scripts/ifup-post
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Source the general functions for is_true() and is_false():
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/ifup-tunnel
+++ b/network-scripts/ifup-tunnel
@@ -20,7 +20,7 @@
 #  - Sean Millichamp <sean@enertronllc.com>
 # for providing the scripts this one is based on
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 cd /etc/sysconfig/network-scripts
 . ./network-functions

--- a/network-scripts/network-functions
+++ b/network-scripts/network-functions
@@ -11,7 +11,7 @@ export PATH
 # (It was previously done for RHEL-6 branch, but got lost in time.)
 HOSTNAME="$(hostname)"
 
-[ -z "$__sed_discard_ignored_files" ] && . /etc/init.d/functions
+[ -z "$__sed_discard_ignored_files" ] && . /etc/rc.d/init.d/functions
 
 get_hwaddr ()
 {

--- a/usr/libexec/readonly-root
+++ b/usr/libexec/readonly-root
@@ -3,7 +3,7 @@
 # Set up readonly-root support.
 #
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 # We need to initialize the $HOSTNAME variable by ourselves now:
 # (It was previously done for RHEL-6 branch, but got lost in time.)

--- a/usr/sbin/service
+++ b/usr/sbin/service
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. /etc/init.d/functions
+. /etc/rc.d/init.d/functions
 
 VERSION="$(basename $0) ver. 1.1"
 USAGE="Usage: $(basename $0) < option > | --status-all | \


### PR DESCRIPTION
The functions file is actually installed into
/etc/rc.d/init.d/functions, not /etc/init.d/functions.

The symlink from /etc/init.d to /etc/rc.d/init.d is provided by the
chkconfig package, but it's not always there.