### PR TITLE
Add ip6gre tunnel option - rhel7

### DIFF
--- a/sysconfig.txt
+++ b/sysconfig.txt
@@ -931,7 +931,7 @@ Files in /etc/sysconfig/network-scripts/
       "mode=active-backup arp_interval=60 arp_ip_target=192.168.1.1,192.168.1.2"
 
   Tunnel-specific items:
-    TYPE=GRE|IPIP|IPIP6
+    TYPE=GRE|GRE6|IPIP|IPIP6
     MY_INNER_IPADDR=local IP address of the tunnel interface
     PEER_OUTER_IPADDR=IP address of the remote tunnel endpoint
     MY_OUTER_IPADDR=IP address of the local tunnel endpoint

--- a/sysconfig/network-scripts/ifup-tunnel
+++ b/sysconfig/network-scripts/ifup-tunnel
@@ -42,6 +42,11 @@ GRE)
     proto=-4
     /sbin/modprobe ip_gre
     ;;
+GRE6)
+    MODE=ip6gre
+    proto=-6
+    /sbin/modprobe ip6_gre
+    ;;
 IPIP)
     MODE=ipip
     proto=-4

--- a/sysconfig/network-scripts/network-functions
+++ b/sysconfig/network-scripts/network-functions
@@ -146,7 +146,7 @@ source_config ()
     CTC)
         DEVICETYPE="ctc"
         ;;
-    GRE | IPIP | IPIP6)
+    GRE | GRE6 | IPIP | IPIP6)
         DEVICETYPE="tunnel"
         ;;
     SIT | sit)


### PR DESCRIPTION
Add option for IPv6 GRE tunnel.

Resolve: [https://bugzilla.redhat.com/show_bug.cgi?id=1691552](url)