### PR TITLE
ifup/ifdown: print DEPRECATION_WARNING_ISSUED waring info after source_config

### DIFF
--- a/network-scripts/ifdown
+++ b/network-scripts/ifdown
@@ -16,12 +16,6 @@ CONFIG=$1
     exit 1
 }
 
-if ! is_true ${DEPRECATION_WARNING_ISSUED}; then
-    net_log $"You are using 'ifdown' script provided by 'network-scripts', which are now deprecated." warning ifdown >&2
-    net_log $"'network-scripts' will be removed from distribution in near future." warning ifdown >&2
-    net_log $"It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well." warning ifdown >&2
-fi
-
 need_config "${CONFIG}"
 
 [ -f "$CONFIG" ] || {
@@ -41,6 +35,12 @@ if [ $UID != 0 ]; then
 fi
 
 source_config
+
+if ! is_true ${DEPRECATION_WARNING_ISSUED}; then
+    net_log $"You are using 'ifdown' script provided by 'network-scripts', which are now deprecated." warning ifdown >&2
+    net_log $"'network-scripts' will be removed from distribution in near future." warning ifdown >&2
+    net_log $"It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well." warning ifdown >&2
+fi
 
 if [ -n "$IN_HOTPLUG" ] && [ "${HOTPLUG}" = "no" -o "${HOTPLUG}" = "NO" ]
 then

--- a/network-scripts/ifup
+++ b/network-scripts/ifup
@@ -31,12 +31,6 @@ CONFIG=${1}
     exit 1
 }
 
-if ! is_true ${DEPRECATION_WARNING_ISSUED}; then
-    net_log $"You are using 'ifup' script provided by 'network-scripts', which are now deprecated." warning ifup >&2
-    net_log $"'network-scripts' will be removed from distribution in near future." warning ifup >&2
-    net_log $"It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well." warning ifup >&2
-fi
-
 need_config "${CONFIG}"
 
 [ -f "${CONFIG}" ] || {
@@ -57,6 +51,12 @@ if [ ${UID} != 0 ]; then
 fi
 
 source_config
+
+if ! is_true ${DEPRECATION_WARNING_ISSUED}; then
+    net_log $"You are using 'ifup' script provided by 'network-scripts', which are now deprecated." warning ifup >&2
+    net_log $"'network-scripts' will be removed from distribution in near future." warning ifup >&2
+    net_log $"It is advised to switch to 'NetworkManager' instead - it provides 'ifup/ifdown' scripts as well." warning ifup >&2
+fi
 
 if [ "foo$2" = "fooboot" ] && [ "${ONBOOT}" = "no" -o "${ONBOOT}" = "NO" ]
 then


### PR DESCRIPTION
In ifup/ifdown scripts, move deprecation waring info after
source_config, so users can config DEPRECATION_WARNING_ISSUED in
ifcfg-** file to decide whether show deprecation waring info when
calling ifup/ifdown.

Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>