### PR TITLE
rc.d/functions: fix escape sequence being output under systemd servic…

### DIFF
--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -84,8 +84,9 @@ if [ -z "${BOOTUP:-}" ]; then
         LOGLEVEL=1
     fi
 
-    # NOTE: /dev/ttyS* is serial console.
-    if tty | grep --quiet -e '/dev/ttyS'; then
+    # NOTE: /dev/ttyS* is serial console. "not a tty" is such as
+    # /dev/null associated when executed under systemd service units.
+    if LANG=C tty | grep --quiet -e '\(/dev/ttyS'\|not a tty\); then
         BOOTUP=serial
         MOVE_TO_COL=
         SETCOLOR_SUCCESS=


### PR DESCRIPTION
…e units

When functions provided by /etc/rc.d/functions is used, escape
sequence is output under systemd service units and logged into
/var/log/messages as follows:

    # LANG=C systemctl cat foobar.service
    # /etc/systemd/system/foobar.service
    [Unit]
    Description=FOOBAR

    [Service]
    Type=oneshot
    ExecStart=/usr/bin/foobar.sh
    RemainAfterExit=yes

    [Install]
    WantedBy=multi-user.target
    # cat /usr/bin/foobar.sh
    #! /bin/bash

    . /etc/init.d/functions
    echo_success
    # LANG=C grep foobar.sh /var/log/messages
    Aug  7 09:29:54 localhost foobar.sh[29607]: #033[60G[#033[1;32m  OK  #033[0;39m]#015#033[60G[#033[1;31mFAILED#033[0;39m]

This is a regression issue caused by the commit f88dbd98e992 where
consoletype command was dropped.

Under systemd service units, standard input is associated with
/dev/null by default:

    # systemctl show -p StandardInput foobar.service
    StandardInput=null

  man 5 systemd.exec:

     StandardInput=
         Controls where file descriptor 0 (STDIN) of the executed
         processes is connected to. Takes one of null, tty,
         tty-force, tty-fail, data, file:path, socket or fd:name.

         If null is selected, standard input will be connected to
         /dev/null, i.e. all read attempts by the process will
         result in immediate EOF.

consoletype command interprets /dev/null as serial:

    # consoletype < /dev/null
    warning: consoletype is now deprecated, and will be removed in the near future!
    warning: use tty (1) instead! More info: 'man 1 tty'
    serial

The commit f88dbd98e992 overlooks this situation.

To fix this issue, check also "not a tty" to cover the case where
standard input is /dev/null.

Note that LANG=C is needed because the message "not a tty" varies
depending on locales.