### PR TITLE
rc.d/functions: fix escape sequence being output under systemd service units

### DIFF
--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -84,8 +84,9 @@ if [ -z "${BOOTUP:-}" ]; then
         LOGLEVEL=1
     fi
 
-    # NOTE: /dev/ttyS* is serial console.
-    if tty | grep --quiet -e '/dev/ttyS'; then
+    # NOTE: /dev/ttyS* is serial console. "not a tty" is such as
+    # /dev/null associated when executed under systemd service units.
+    if LANG=C tty | grep --quiet -e '\(/dev/ttyS\|not a tty\)'; then
         BOOTUP=serial
         MOVE_TO_COL=
         SETCOLOR_SUCCESS=


### PR DESCRIPTION
Fix issue when functions provided by ``/etc/rc.d/functions`` is used, escape sequence is output under systemd service units and logged into ``/var/log/messages``.

This is a regression issue caused by the commit f88dbd98e992 where
consoletype command was dropped.

Resolves: [https://bugzilla.redhat.com/show_bug.cgi?id=1738436](url)