### PR TITLE
ifup-eth: Fix bridge setting stp option

### DIFF
--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -59,7 +59,7 @@ if [ "${TYPE}" = "Bridge" ]; then
 
     if [ ! -d /sys/class/net/${DEVICE}/bridge ]; then
         ip link add ${DEVICE} type bridge $bridge_opts || exit 1
-    elif [ -n "${OPTS}" ]; then
+    elif [ -n "${bridge_opts}" ]; then
         ip link set ${DEVICE} type bridge $bridge_opts || exit 1
     fi
     unset bridge_opts


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/1743522

An uninitialized variable was copied from a closed PR [1]
to submitted PR [2].

[1] https://github.com/fedora-sysv/initscripts/pull/212
[2] https://github.com/fedora-sysv/initscripts/pull/213

Signed-off-by: Bell Levin <blevin@redhat.com>