### PR TITLE
Stop disabling IPV6 by default

### DIFF
--- a/network-scripts/ifup-aliases
+++ b/network-scripts/ifup-aliases
@@ -346,7 +346,7 @@ for FILE in ifcfg-${parent_device}-range* ; do
     while [ $ipaddr_num -le $ipaddr_endnum ]; do
         IPADDR="$ipaddr_prefix.$ipaddr_num"
         DEVICE="$parent_device:$ipaddr_clonenum"
-        IPV6INIT="no"
+        IPV6INIT="yes"
         ! is_false "$ONPARENT" && new_interface
         ipaddr_num=$(($ipaddr_num+1))
         ipaddr_clonenum=$(($ipaddr_clonenum+1))


### PR DESCRIPTION
With this default setting, when changing from one Wifi network to another, IPV6 was always disabled, even if it was enabled in the source network-script file.