### PR TITLE
rc.local: Initscripts no longer care about rc.local 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,6 @@ install-post: install-etc
 	    install -m 0755 -d $$dir; \
 	    ln -srf $(DESTDIR)$(sysconfdir)/rc.d/rc$$idx.d $(DESTDIR)$(sysconfdir)/; \
 	done
-	touch $(DESTDIR)$(sysconfdir)/rc.d/rc.local
-	chmod 0755 $(DESTDIR)$(sysconfdir)/rc.d/rc.local
 
 clean:
 	$(MAKE) clean -C src

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -275,8 +275,6 @@ fi
 
 # ---------------
 
-%ghost %config(noreplace, missingok) %verify(not md5 size mtime) %{_sysconfdir}/rc.d/rc.local
-
 %{_sysconfdir}/rc.d/init.d/functions
 
 # RC symlinks:


### PR DESCRIPTION
File rc.local is owned by systemd, so initscripts should not touch it any more.