### PR TITLE
 Wait for scope link addresses as well as for scope global addresses

### DIFF
--- a/network-scripts/network-functions-ipv6
+++ b/network-scripts/network-functions-ipv6
@@ -1058,7 +1058,7 @@ ipv6_wait_tentative() {
     [ "$device" = lo ] && return 0
 
     while [ ${countdown} -gt 0 ]; do
-        ip_output="$(ip -6 addr show dev ${device} scope global tentative)"
+        ip_output="$(ip -6 addr show dev ${device} tentative)"
 
         if [ -z "$ip_output" ]; then
             return 0;
@@ -1073,11 +1073,11 @@ ipv6_wait_tentative() {
         countdown=$(($countdown - 1))
     done
 
-    ip_output="$(ip -6 addr show dev ${device} scope global tentative)"
+    ip_output="$(ip -6 addr show dev ${device} tentative)"
 
     if [ -n "$ip_output" ]; then
         net_log $"Some IPv6 address(es) of ${device} remain still in 'tentative' state" warning $fn
-        net_log $"Run 'ip -6 addr show dev ${device} scope global tentative' to see more" warning $fn
+        net_log $"Run 'ip -6 addr show dev ${device} tentative' to see more" warning $fn
     fi
 
     return 0


### PR DESCRIPTION
Fix issue when interface has assigned only local address in tentative state and DHCPv6 isn't able to assign address to that interface. With this patch network-scripts will wait until tentative state is gone (wait for DAD) for all scopes including local one.

Resolves: #1809601