### PR TITLE
ifup-eth: Switch to bc utility, which supports floating point computations. - RHEL8

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -95,6 +95,7 @@ Requires:         %{name}%{?_isa} = %{version}-%{release}
 
 %shared_requirements
 
+Requires:         bc
 Requires:         dbus
 Requires:         gawk
 Requires:         grep

--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -89,9 +89,11 @@ if [ "${TYPE}" = "Bridge" ]; then
           forward_delay="$(convert2sec ${forward_delay} centi)"
         fi
 
-        forward_delay=$(expr ${forward_delay} \* 2 + 7)
+        forward_delay=$(bc -q <<< "${forward_delay} * 2 + 7")
 
-        [ 0$LINKDELAY -lt $forward_delay ] && LINKDELAY=$forward_delay
+        # It's possible we are comparing floating point numbers here, therefore
+        # we are using 'bc' for comparison. The [ ] and [[ ]] do not work.
+        (( $(bc -l <<< "${LINKDELAY:-0} < ${forward_delay}") )) && LINKDELAY=${forward_delay}
 
         unset forward_delay
     fi


### PR DESCRIPTION
backport of: 0be5319
Resolves:    #1826637