### PR TITLE
rwtab: Add support for chrony

### DIFF
--- a/rwtab
+++ b/rwtab
@@ -20,6 +20,7 @@ empty	/var/lib/php
 empty	/var/lib/pulse
 empty	/var/lib/systemd/timers
 empty	/var/lib/ups
+empty /var/lib/chrony
 empty	/var/tmp
 
 files	/etc/adjtime
@@ -41,5 +42,5 @@ files	/var/empty/sshd/etc/localtime
 files	/var/lib/systemd/random-seed
 files	/var/spool
 files	/var/lib/samba
-files   /var/log/audit/audit.log
+files /var/log/audit/audit.log
 files	/var/lib/nfs


### PR DESCRIPTION
Chrony isn't able to write into its files while stateless mode is
active. This patch should avoid this issue.

Resolves: #1838260