### PR TITLE
rwtab: Add support for chrony

### DIFF
--- a/etc/rwtab
+++ b/etc/rwtab
@@ -20,6 +20,7 @@ empty	/var/lib/php
 empty	/var/lib/pulse
 empty	/var/lib/systemd/timers
 empty	/var/lib/ups
+empty /var/lib/chrony
 empty	/var/tmp
 
 files	/etc/adjtime
@@ -41,5 +42,5 @@ files	/var/empty/sshd/etc/localtime
 files	/var/lib/systemd/random-seed
 files	/var/spool
 files	/var/lib/samba
-files   /var/log/audit/audit.log
+files /var/log/audit/audit.log
 files	/var/lib/nfs


### PR DESCRIPTION
Chrony isn't able to write into its files while stateless mode is
active. This patch should avoid this issue.

(cherry picked from commit 21c44a8e9a68a3a9d39a7fe003096434cea904ea)