### PR TITLE
Add optional 'dev' keyword

### DIFF
--- a/network-scripts/ifup
+++ b/network-scripts/ifup
@@ -140,7 +140,7 @@ if [ "${VLAN}" = "yes" ] && [ "$ISALIAS" = "no" ] && [ -n "$DEVICE" ]; then
                 exit 1
             }
 
-            [ -n "${VLAN_EGRESS_PRIORITY_MAP}" ] && ip link set ${DEVICE} type vlan egress ${VLAN_EGRESS_PRIORITY_MAP}
+            [ -n "${VLAN_EGRESS_PRIORITY_MAP}" ] && ip link set dev ${DEVICE} type vlan egress ${VLAN_EGRESS_PRIORITY_MAP}
         fi
     fi
 

--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -60,7 +60,7 @@ if [ "${TYPE}" = "Bridge" ]; then
     if [ ! -d /sys/class/net/${DEVICE}/bridge ]; then
         ip link add ${DEVICE} type bridge $bridge_opts || exit 1
     elif [ -n "${bridge_opts}" ]; then
-        ip link set ${DEVICE} type bridge $bridge_opts || exit 1
+        ip link set dev ${DEVICE} type bridge $bridge_opts || exit 1
     fi
     unset bridge_opts
 
@@ -189,7 +189,7 @@ if [ -n "${BRIDGE}" ]; then
     /sbin/ip link set dev ${DEVICE} up
     ethtool_set
     [ -n "${LINKDELAY}" ] && /bin/sleep ${LINKDELAY}
-    ip link set ${DEVICE} master ${BRIDGE}
+    ip link set dev ${DEVICE} master ${BRIDGE}
     # add the bits to setup driver parameters here
     for arg in $BRIDGING_OPTS ; do
         key=${arg%%=*};


### PR DESCRIPTION
Fix the problem when the device name could be interpreted as an iproute2 keyword. For example, for a bridge slave named "a" the iproute2 would treat the name as a prefix of keyword "address" and the network-scripts would fail to set the bridge master.

Resolves: rhbz #1859785

(cherry picked from commit 100ed46b483b50059b3be796bafaf7b8f2b99220)