### PR TITLE
rc.d/functions: replace grep's --quiet with -q

### DIFF
--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -86,7 +86,7 @@ if [ -z "${BOOTUP:-}" ]; then
 
     # NOTE: /dev/ttyS* is serial console. "not a tty" is such as
     # /dev/null associated when executed under systemd service units.
-    if LANG=C tty | grep --quiet -e '\(/dev/ttyS\|not a tty\)'; then
+    if LANG=C tty | grep -q -e '\(/dev/ttyS\|not a tty\)'; then
         BOOTUP=serial
         MOVE_TO_COL=
         SETCOLOR_SUCCESS=


### PR DESCRIPTION
Some versions of grep (like busybox's) do not support --quiet.
So use -q instead like in the rest of the file.

Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>