### PR TITLE
Allow updating mlocate.db while in readonly root mode

### DIFF
--- a/etc/rwtab
+++ b/etc/rwtab
@@ -4,6 +4,7 @@ dirs	/var/lib/xkb
 dirs	/var/log
 dirs	/var/lib/puppet
 dirs	/var/lib/dbus
+dirs	/var/lib/mlocate
 
 empty	/tmp
 empty	/var/cache/foomatic


### PR DESCRIPTION
Fixes issue when updatedb does not have the ability to update the mlocate.db