### PR TITLE
Allow updating mlocate.db while in readonly root mode

### DIFF
--- a/rwtab
+++ b/rwtab
@@ -4,6 +4,7 @@ dirs	/var/lib/xkb
 dirs	/var/log
 dirs	/var/lib/puppet
 dirs	/var/lib/dbus
+dirs	/var/lib/mlocate
 
 empty	/tmp
 empty	/var/cache/foomatic


### PR DESCRIPTION
Fixes issue when updatedb does not have the ability to update the mlocate.db

Resolves: #1880095

(cherry picked from commit c59a7612bac9b9d0c2b55eb9a251bb43690220b0)