### PR TITLE
Allow updating rfkill switch status while in readonly root mode

### DIFF
--- a/etc/rwtab
+++ b/etc/rwtab
@@ -5,6 +5,7 @@ dirs	/var/log
 dirs	/var/lib/puppet
 dirs	/var/lib/dbus
 dirs	/var/lib/mlocate
+dirs	/var/lib/systemd/rfkill
 
 empty	/tmp
 empty	/var/cache/foomatic


### PR DESCRIPTION
Adding rfkill switch status into rwtab.