### PR TITLE
Allow updating rfkill switch status while in readonly root mode

### DIFF
--- a/etc/rwtab
+++ b/etc/rwtab
@@ -5,6 +5,7 @@ dirs	/var/log
 dirs	/var/lib/puppet
 dirs	/var/lib/dbus
 dirs	/var/lib/mlocate
+dirs	/var/lib/systemd/rfkill
 
 empty	/tmp
 empty	/var/cache/foomatic


### PR DESCRIPTION
Adding rfkill switch status into rwtab.

Resolves: #1878874

(cherry picked from commit 537a39f10173d34cd9a2cf75e42225bb339c318e)