### PR TITLE
makefile: Use rpmdev-bumpspec's legacy date option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ tag:
 
 release-commit:
 	@git log --decorate=no --format="- %s" $(VERSION)..HEAD > .changelog.tmp
-	@rpmdev-bumpspec -n $(NEXT_VERSION) -f .changelog.tmp initscripts.spec
+	@rpmdev-bumpspec -D -n $(NEXT_VERSION) -f .changelog.tmp initscripts.spec
 	@rm -f .changelog.tmp
 	@git add initscripts.spec
 	@git commit --message="$(NEXT_VERSION)"

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -350,7 +350,7 @@ fi
 # =============================================================================
 
 %changelog
-* Fri Nov  6 09:25:48 CET 2020 Jan Macku <jamacku@redhat.com> - 10.05-1
+* Fri Nov 06 2020 Jan Macku <jamacku@redhat.com> - 10.05-1
 - service: Prevent variables from globbing
 - init.d/functions: Make usage msgs more clear
 - network-scripts: Use net_log() instead of logger


### PR DESCRIPTION
Start using legacy date-stamp to remain consistent changelog