### PR TITLE
makefile: Use rpmdev-bumpspec's legacy date option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ tag:
 
 release-commit:
 	@git log --decorate=no --format="- %s" $(VERSION)..HEAD > .changelog.tmp
-	@rpmdev-bumpspec -n $(NEXT_VERSION) -f .changelog.tmp initscripts.spec
+	@rpmdev-bumpspec -D -n $(NEXT_VERSION) -f .changelog.tmp initscripts.spec
 	@rm -f .changelog.tmp
 	@git add initscripts.spec
 	@git commit --message="$(NEXT_VERSION)"

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -346,7 +346,7 @@ fi
 # =============================================================================
 
 %changelog
-* Fri Nov  6 09:07:07 CET 2020 Jan Macku <jamacku@redhat.com> - 10.00.10-1
+* Fri Nov 06 2020 Jan Macku <jamacku@redhat.com> - 10.00.10-1
 - Allow updating rfkill switch status while in readonly root mode
 - service: Prevent variables from globbing
 - Allow updating mlocate.db while in readonly root mode


### PR DESCRIPTION
Start using legacy date-stamp to remain consistent changelog