### PR TITLE
network: add option to keep the link down

### DIFF
--- a/network-scripts/ifup
+++ b/network-scripts/ifup
@@ -122,7 +122,7 @@ if is_true "${VLAN}" && is_false "$ISALIAS" && [ -n "$DEVICE" ]; then
         }
 
         # Link on Physical device needs to be up but no ip required
-        check_device_down ${PHYSDEV} && { ip -o link set dev ${PHYSDEV} up; }
+        check_device_down ${PHYSDEV} && set_link_up ${PHYSDEV}
 
         if [ ! -f /proc/net/vlan/${DEVICE} ]; then
             if is_false "${REORDER_HDR}"; then

--- a/network-scripts/ifup-ctc
+++ b/network-scripts/ifup-ctc
@@ -26,7 +26,7 @@ fi
 
 [ -z "$PREFIX" ] && eval $(/bin/ipcalc --prefix ${IPADDR} ${NETMASK})
 ip addr add ${IPADDR} peer ${GATEWAY}/${PREFIX} dev ${DEVICE}
-ip link set up dev ${DEVICE}
+set_link_up ${DEVICE}
 # Wait for the device to come up - the chandev'ified ctc driver can take
 # quite a while...
 timeout=0

--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -76,7 +76,7 @@ if [ "${TYPE}" = "Bridge" ]; then
     # set LINKDELAY (used as timeout when calling check_link_down())
     # to at least (${DELAY} * 2) + 7 if STP is enabled. This is the
     # minimum time required for /sys/class/net/$REALDEVICE/carrier to
-    # become 1 after "ip link set dev $DEVICE up" is called.
+    # become 1 after "set_link_up $DEVICE" is called.
     if is_true "${STP}"; then
         if [ -n "${DELAY}" ]; then
           forward_delay="${DELAY}"
@@ -164,7 +164,7 @@ fi
 # so it can actually get an IP.
 if is_false "$ISALIAS" && is_bonding_device ${DEVICE}; then
     install_bonding_driver ${DEVICE}
-    /sbin/ip link set dev ${DEVICE} up
+    set_link_up ${DEVICE}
     for device in $(LANG=C grep -l "^[[:space:]]*MASTER=['\"]\?${DEVICE}['\"]\?\([[:space:]#]\|$\)" /etc/sysconfig/network-scripts/ifcfg-*) ; do
         is_ignored_file "$device" && continue
         /sbin/ifup ${device##*/} || net_log "Unable to start slave device ${device##*/} for master ${DEVICE}." warning
@@ -188,7 +188,7 @@ if [ -n "${BRIDGE}" ]; then
         ip link add ${BRIDGE} type bridge 2>/dev/null
     fi
     /sbin/ip addr flush dev ${DEVICE} 2>/dev/null
-    /sbin/ip link set dev ${DEVICE} up
+    set_link_up ${DEVICE}
     ethtool_set
     [ -n "${LINKDELAY}" ] && /bin/sleep ${LINKDELAY}
     ip link set dev ${DEVICE} master ${BRIDGE}
@@ -243,7 +243,7 @@ if [ -n "${DYNCONFIG}" ] && [ -x /sbin/dhclient ]; then
 else 
     if [ -z "${IPADDR}" -a -z "${IPADDR0}" -a -z "${IPADDR1}" -a -z "${IPADDR2}" ]; then
         # enable device without IP, useful for e.g. PPPoE
-        ip link set dev ${REALDEVICE} up
+        set_link_up ${REALDEVICE}
         ethtool_set
         [ -n "${LINKDELAY}" ] && /bin/sleep ${LINKDELAY}
     else
@@ -253,7 +253,7 @@ else
         [ -n "${ARP}" ] && \
             ip link set dev ${REALDEVICE} $(toggle_value arp $ARP)
 
-        if ! ip link set dev ${REALDEVICE} up ; then
+        if ! set_link_up ${REALDEVICE} ; then
             net_log $"Failed to bring up ${DEVICE}."
             exit 1
         fi

--- a/network-scripts/ifup-ippp
+++ b/network-scripts/ifup-ippp
@@ -342,7 +342,7 @@ function addprovider()
     # activate ISDN device
     net_log $"ip addr add $IPADDR peer $GATEWAY${pfx:/$pfx} dev $DEVICE" info ifup-ippp
     ip addr add $IPADDR peer $GATEWAY${pfx:/$pfx} dev $DEVICE
-    ip link set dev $DEVICE up
+    set_link_up ${DEVICE}
 
     if [ "$ENCAP" = "syncppp" ]; then
         # start ipppd daemon

--- a/network-scripts/ifup-plip
+++ b/network-scripts/ifup-plip
@@ -12,7 +12,7 @@ fi
 
 [ -z "$PREFIX" ] && eval $(/bin/ipcalc --prefix ${IPADDR} ${NETMASK})
 ip addr add ${IPADDR} peer ${REMIP}/${PREFIX} dev ${DEVICE}
-ip link set up dev ${DEVICE}
+set_link_up ${DEVICE}
 ip route add ${NETWORK} dev ${DEVICE}
 
 . /etc/sysconfig/network

--- a/network-scripts/ifup-plusb
+++ b/network-scripts/ifup-plusb
@@ -29,7 +29,7 @@ if [ ${BROADCAST} != ""  ]  ; then
 else
     ip addr add ${IPADDR} peer ${REMIP}/${PREFIX} dev ${DEVICE}
 fi
-ip link set up dev ${DEVICE}
+set_link_up ${DEVICE}
 
 . /etc/sysconfig/network
 

--- a/network-scripts/ifup-tunnel
+++ b/network-scripts/ifup-tunnel
@@ -91,7 +91,7 @@ fi
 /sbin/ip addr add "$MY_INNER_IPADDR" dev "$DEVICE" \
     ${PEER_INNER_IPADDR:+peer "$PEER_INNER_IPADDR"}
 
-/sbin/ip link set dev "$DEVICE" up
+set_link_up "${DEVICE}"
 
 # IPv6 initialisation?
 /etc/sysconfig/network-scripts/ifup-ipv6 ${CONFIG}

--- a/network-scripts/network-functions
+++ b/network-scripts/network-functions
@@ -457,11 +457,18 @@ check_device_down ()
     fi
 }
 
+set_link_up ()
+{
+    if [ "$LINKSTATUS" = down ]; then
+        ip link set dev $1 up >/dev/null 2>&1
+    else
+        grep -qsx 1 /sys/class/net/$1/carrier
+    fi
+}
+
 check_link_down ()
 {
-    if ! LC_ALL=C ip link show dev $1 2>/dev/null| grep -q ",UP" ; then
-        ip link set dev $1 up >/dev/null 2>&1
-    fi
+    set_link_up $1
     timeout=0
     delay=10
     [ -n "$LINKDELAY" ] && delay=$(($LINKDELAY * 2))

--- a/network-scripts/network-functions-ipv6
+++ b/network-scripts/network-functions-ipv6
@@ -10,6 +10,8 @@
 #
 #
 
+# Source network-functions due to need of set_link_up()
+. ./network-functions
 
 ##### Test for IPv6 capabilities
 # $1: (optional) testflag: currently supported: "testonly" (do not load a module)
@@ -108,7 +110,7 @@ ipv6_enable_autotunnel() {
         true
     else
         # bring up basic tunnel device
-        /sbin/ip link set sit0 up
+        set_link_up sit0
 
             if ! ipv6_test_device_status sit0; then
                 net_log $"Tunnel device 'sit0' enabling didn't work" err $fn
@@ -159,7 +161,7 @@ ipv6_add_addr_on_device() {
         net_log $"Device '$device' doesn't exist" err $fn
         return 3
     else
-        /sbin/ip link set $device up
+        set_link_up $device
 
             if ! ipv6_test_device_status $device; then
                 net_log $"Device '$device' enabling didn't work" err $fn
@@ -604,7 +606,7 @@ ipv6_add_tunnel_device() {
             return 3
         fi
 
-        /sbin/ip link set $device up
+        set_link_up $device
 
         if ! ipv6_test_device_status $device; then
             net_log $"Tunnel device '$device' bringing up didn't work" err $fn


### PR DESCRIPTION
Some interfaces like Open vSwitch bridges using the userspace datapath,
needs the link to be kept down to avoid issues.
Add a LINKSTATUS=[down|up] ifcfg parameter to add this functionality.
If not specified, the link will default to up as before.

Patch provided by Matteo Croce <mcroce@redhat.com>