### PR TITLE
Revert "remove rename_device_lock when process does not exist"

### DIFF
--- a/src/rename_device.c
+++ b/src/rename_device.c
@@ -278,14 +278,6 @@ char *get_config_by_hwaddr(char *hwaddr, char *current) {
 	return first;
 }
 
-int pid_exist(int pid)
-{
-	char proc_dir[32];
-	sprintf(proc_dir, "/proc/%d/", pid);
-	return !access(proc_dir, F_OK);
-}
-
-
 void take_lock() {
 	int count = 0;
 	int lockfd;
@@ -317,11 +309,7 @@ void take_lock() {
 			close(fd);
 			pid = atoi(buf);
 			if (pid && pid != 1) {
-				if (pid_exist(pid))
-					kill(pid,SIGKILL);
-				else
-					if (unlink(LOCKFILE) != 0)
-						break;
+				kill(pid,SIGKILL);
 			}
 		}
 		usleep(100000);


### PR DESCRIPTION
Reverts fedora-sysv/initscripts#359