### PR TITLE
spec: sync with Fedora

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -46,6 +46,7 @@ BuildRequires:    glib2-devel
 BuildRequires:    pkgconfig
 BuildRequires:    popt-devel
 BuildRequires:    setup
+BuildRequires:    make
 
 %{?systemd_requires}
 BuildRequires:    systemd


### PR DESCRIPTION
Add BuildRequires: make

https://fedoraproject.org/wiki/Changes/Remove_make_from_BuildRoot