### PR TITLE
 network scripts: Avoid infinite loop of arping

### DIFF
--- a/doc/sysconfig.txt
+++ b/doc/sysconfig.txt
@@ -534,11 +534,21 @@ Files in /etc/sysconfig/network-scripts/
       If set to 'no', ifup will not try to determine, if requested ip address
       is used by other machine in network.
       Defaults to 'yes'.
+    ARPING_WAIT=<number>
+      Number of seconds for which will be arping trying to determine, if requested ip
+      address is used in network. This option works with ARPCHECKn=yes
+      If not set default is 3 sec.  
+      example: ARPING_WAIT=1
     ARPUPDATE=yes|no
       If set to 'no' the neighbours in current network will not be updated with
       ARP information about this NIC. This is especially handy using LVS Load
       Balancing with Direct Routing enabled.
       Defaults to 'yes'.
+    ARPING_UPDATE_WAIT=<number>
+      Number of seconds for which will be arping trying to update arp cache
+      of neighbours with ARP informations about this NIC.
+      This option works with ARPUPDATE=yes. If not set default is 3 sec.  
+      example: ARPING_UPDATE_WAIT=1
     IPV4_FAILURE_FATAL=yes|no
       If set to yes, ifup-eth will end immediately after ipv4 dhclient fails.
       Defaults to 'no'.

--- a/network-scripts/ifup-aliases
+++ b/network-scripts/ifup-aliases
@@ -280,8 +280,9 @@ function new_interface ()
 
         # update ARP cache of neighboring computers:
         if ! is_false "${ARPUPDATE}" && [ "${REALDEVICE}" != "lo" ]; then
-            /sbin/arping -q -A -c 1 -I ${parent_device} ${IPADDR}
-            ( sleep 2; /sbin/arping -q -U -c 1 -I ${parent_device} ${IPADDR} ) > /dev/null 2>&1 < /dev/null &
+            /sbin/arping -q -A -c 1 -w ${ARPING_UPDATE_WAIT:-3} -I ${parent_device} ${IPADDR}
+            ( sleep 2;
+            /sbin/arping -q -U -c 1 -w ${ARPING_UPDATE_WAIT:-3} -I ${parent_device} ${IPADDR} ) > /dev/null 2>&1 < /dev/null &
         fi
 
         ! is_false "$IPV6INIT" && \

--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -302,9 +302,9 @@ else
 
             # update ARP cache of neighboring computers
             if ! is_false "${arpupdate[$idx]}" && [ "${REALDEVICE}" != "lo" ]; then
-                /sbin/arping -q -A -c 1 -I ${REALDEVICE} ${ipaddr[$idx]}
+                /sbin/arping -q -A -c 1 -w ${ARPING_UPDATE_WAIT:-3} -I ${REALDEVICE} ${ipaddr[$idx]}
                 ( sleep 2;
-                /sbin/arping -q -U -c 1 -I ${REALDEVICE} ${ipaddr[$idx]} ) > /dev/null 2>&1 < /dev/null &
+                /sbin/arping -q -U -c 1 -w ${ARPING_UPDATE_WAIT:-3} -I ${REALDEVICE} ${ipaddr[$idx]} ) > /dev/null 2>&1 < /dev/null &
             fi
 
             # set lifetime of address to forever


### PR DESCRIPTION
Introduced in the bonding driver (commit ae46f184bc1f) Driver now reports transmission failures.
Before that, it silently dropped the packet and replied with success error code.

The arping of iputils retries endlessly when a transmission error occurs.

This patch fix this behavior.