### PR TITLE
spec: Move service script into subpackage

### DIFF
--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -605,6 +605,7 @@ strstr() {
 }
 
 # Check whether file $1 is a backup or rpm-generated file and should be ignored
+# Copy of the function is present in usr/sbin/service
 is_ignored_file() {
     case "$1" in
     *~ | *.bak | *.old | *.orig | *.rpmnew | *.rpmorig | *.rpmsave)

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -34,6 +34,7 @@ Requires:         procps-ng
 Requires:         setup
 Requires:         systemd
 Requires:         util-linux
+Recommends:       initscripts-service
 
 Requires(pre):    shadow-utils
 Requires(post):   coreutils
@@ -50,8 +51,6 @@ BuildRequires:    make
 
 %{?systemd_requires}
 BuildRequires:    systemd
-
-Provides:         /sbin/service
 
 Obsoletes:        %{name}            < 9.82-2
 
@@ -88,6 +87,23 @@ This package provides basic support for legacy System V init scripts, and some
 other legacy tools & utilities.
 
 # === SUBPACKAGES =============================================================
+
+%package -n initscripts-service
+Summary:          Support for service command
+BuildArch:        noarch
+
+%shared_requirements
+
+Requires:         systemd
+
+Provides:         /sbin/service
+
+Obsoletes:        %{name}            < 9.82-2
+
+%description -n initscripts-service
+This package provides service command.
+
+# ---------------
 
 %package -n network-scripts
 Summary:          Legacy scripts for manipulating of network devices
@@ -292,7 +308,6 @@ fi
 %{_bindir}/*
 %{_sbindir}/consoletype
 %{_sbindir}/genhostid
-%{_sbindir}/service
 
 %{_libexecdir}/import-state
 %{_libexecdir}/loadmodules
@@ -304,9 +319,19 @@ fi
 %{_udevrulesdir}/*
 
 %{_mandir}/man1/*
-%{_mandir}/man8/service.*
 
 # =============================================================================
+
+%files -n initscripts-service
+
+%dir %{_libexecdir}/%{name}
+%dir %{_libexecdir}/%{name}/legacy-actions
+
+%{_sbindir}/service
+
+%{_mandir}/man8/service.*
+
+# ---------------
 
 %files -n network-scripts
 %doc doc/examples/

--- a/usr/sbin/service
+++ b/usr/sbin/service
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-. /etc/init.d/functions
+# Check whether file $1 is a backup or rpm-generated file and should be ignored
+# Copy of the function from etc/rc.d/init.d/functions
+is_ignored_file() {
+    case "$1" in
+    *~ | *.bak | *.old | *.orig | *.rpmnew | *.rpmorig | *.rpmsave)
+        return 0
+        ;;
+    esac
+    return 1
+}
 
 VERSION="$(basename $0) ver. 1.1"
 USAGE="Usage: $(basename $0) < option > | --status-all | \


### PR DESCRIPTION
This changes moves service script into `initscripts-service` subpackage. The subpackage
could be install without main package.

This change allows `audit` not to require `initscripts` and require only `initscripts-service` instead.

Requested by: msekleta@redhat.com