### PR TITLE
spec: Initscripts now requires chkconfig

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -34,6 +34,7 @@ Requires:         procps-ng
 Requires:         setup
 Requires:         systemd
 Requires:         util-linux
+Requires:         chkconfig
 Recommends:       initscripts-service
 
 Requires(pre):    shadow-utils


### PR DESCRIPTION
As a easy way to get full legacy system V support.