### PR TITLE
specfile: Update obsoletes to allow upgrades

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -99,7 +99,7 @@ Requires:         systemd
 
 Provides:         /sbin/service
 
-Obsoletes:        %{name}            < 9.82-2
+Obsoletes:        %{name}            < 10.10-1
 
 %description -n initscripts-service
 This package provides service command.


### PR DESCRIPTION
Obsoletes with initscripts < 10.10 in order to allow the initscripts-service package to be installed while upgrading from initscripts < 10.10