### PR TITLE
Make the init.d/network and init.d/functions available on Busybox's shell

### DIFF
--- a/etc/rc.d/init.d/functions
+++ b/etc/rc.d/init.d/functions
@@ -123,7 +123,7 @@ __kill_pids_term_kill_checkpids() {
         stime=${stat[21]}
 
         [ -n "$stime" ] && [ "$base_stime" -lt "$stime" ] && continue
-        remaining+="$pid "
+        remaining="$remaining$pid "
     done
 
     echo "$remaining"

--- a/network-scripts/ifup-eth
+++ b/network-scripts/ifup-eth
@@ -100,11 +100,11 @@ if [ "${TYPE}" = "Bridge" ]; then
           forward_delay="$(convert2sec ${forward_delay} centi)"
         fi
 
-        forward_delay=$(bc -q <<< "${forward_delay} * 2 + 7")
+        forward_delay=$(echo "${forward_delay} * 2 + 7" | bc -q)
 
         # It's possible we are comparing floating point numbers here, therefore
         # we are using 'bc' for comparison. The [ ] and [[ ]] do not work.
-        (( $(bc -l <<< "${LINKDELAY:-0} < ${forward_delay}") )) && LINKDELAY=${forward_delay}
+        (( $(echo "${LINKDELAY:-0} < ${forward_delay}" | bc -l) )) && LINKDELAY=${forward_delay}
 
         unset forward_delay
     fi

--- a/network-scripts/network-functions
+++ b/network-scripts/network-functions
@@ -163,10 +163,10 @@ source_config ()
         ;;
     esac
     if [ -n "$HWADDR" ]; then
-        HWADDR=$(tr '[a-z]' '[A-Z]' <<<"$HWADDR")
+        HWADDR=$(echo "$HWADDR" | tr '[a-z]' '[A-Z]')
     fi
     if [ -n "$MACADDR" ]; then
-        MACADDR=$(tr '[a-z]' '[A-Z]' <<<"$MACADDR")
+        MACADDR=$(echo "$MACADDR" | tr '[a-z]' '[A-Z]')
     fi
     [ -z "$DEVICE" -a -n "$HWADDR" ] && DEVICE=$(get_device_by_hwaddr $HWADDR)
     [ -z "$DEVICETYPE" ] && DEVICETYPE=$(echo ${DEVICE} | sed "s/[0-9]*$//")

--- a/network-scripts/network-functions
+++ b/network-scripts/network-functions
@@ -572,7 +572,7 @@ install_bonding_driver ()
 
             # add the bits to setup driver parameters here
             # first set mode, miimon
-            for (( idx=0; idx < ${#bopts_keys[*]}; idx++ )) ; do
+            for idx in $(seq 0 $(( ${#bopts_keys[*]} - 1 ))) ; do
                 key=${bopts_keys[$idx]}
                 value=${bopts_vals[$idx]}
 
@@ -591,7 +591,7 @@ install_bonding_driver ()
             done
 
             # set all other remaining options
-            for (( idx=0; idx < ${#bopts_keys[*]}; idx++ )) ; do
+            for idx in $(seq 0 $(( ${#bopts_keys[*]} - 1 ))) ; do
                 key=${bopts_keys[$idx]}
                 value=${bopts_vals[$idx]}
 


### PR DESCRIPTION
#396 
In some embedded environments, instead of using GNU Bash for size reasons, the Ash (shell provided by busybox) is used. But init.d/network and init.d/functions are not very well adapted for Ash. Here are the two problems I found:

1) Use killproc to kill the given service process
   Steps:
```
	#!/bin/bash
	. /etc/init.d/functions

	test()
	{
		sleep 30 &
		killproc sleep
	}
	test
```
   run this testcase returns an error, and sleep is not killed:
	# ./test_killproc.sh: line 126: remainning+=2039 : not found

   This is because Ash cannot use "+=" for string concatenation.

2) I found out that here string(<<<) and c-style for-loop( for (( ; ; )) ) are
   used in network-scripts. But Ash doesn't support them either. So when I run:
   "/etc/rc.d/init.d/network status" gives these errors:
```
	# /etc/rc.d/init.d/network: ./network-functions: line 166: syntax error: unexpected redirection
	# /etc/rc.d/init.d/network: ./network-functions: line 575: syntax error: bad for loop variable
```
   The last two patches are used to fix this problem.

The problems mentioned above can all be verified simply on busybox v1.32.1. For example:
```
   $ /bin/busybox bash -c "str+=$char"
   bash: str+=: not found

   $ /bin/busybox bash -c "grep hello <<< "hello world""
   world: line 1: syntax error: unexpected redirection

   $ /bin/busybox bash -c "for (( idx=0; idx<5; idx++ )); do date; done"
   bash: syntax error: bad for loop variable
```

Thanks in advance.