### PR TITLE
ifup-routes: Use `ip route repace` to avoid race

### DIFF
--- a/network-scripts/ifup-routes
+++ b/network-scripts/ifup-routes
@@ -19,7 +19,7 @@ handle_file () {
             line="$line via $(eval echo '$'GATEWAY$routenum)"
         fi
         line="$line dev $2"
-        /sbin/ip route add $line
+        /sbin/ip route replace $line
         routenum=$(($routenum+1))
     done
 }
@@ -34,7 +34,7 @@ handle_ip_file() {
     fi
     { cat "$file" ; echo ; } | while read line; do
         if [[ ! "$line" =~ $MATCH ]]; then
-            /sbin/ip $proto $type add $line
+            /sbin/ip $proto $type replace $line
         fi
     done
 }


### PR DESCRIPTION
This should resolve the scenario when the link is brought up prior to disabling `accept_ra`.

This only happens when both IPv4 and IPv6 address is on the interface, because network-scripts does IPv4 first and brings up the interface.

Then it does IPv6 which disables the RA's, at that point the node has already learned the route from RA and setting a default route fails.

Using `ip route replace` we ensure if the above scenario happens we end-up with the correct default ipv6 route.

Huge thanks to @hjensas who debugged this issue and prepared a patch!

Related: [`#2034799`](https://bugzilla.redhat.com/show_bug.cgi?id=2034799)