### PR TITLE
ifup-routes: Use `ip route repace` to avoid race

### DIFF
--- a/network-scripts/ifup-routes
+++ b/network-scripts/ifup-routes
@@ -19,7 +19,7 @@ handle_file () {
             line="$line via $(eval echo '$'GATEWAY$routenum)"
         fi
         line="$line dev $2"
-        /sbin/ip route add $line
+        /sbin/ip route replace $line
         routenum=$(($routenum+1))
     done
 }
@@ -34,7 +34,7 @@ handle_ip_file() {
     fi
     { cat "$file" ; echo ; } | while read line; do
         if [[ ! "$line" =~ $MATCH ]]; then
-            /sbin/ip $proto $type add $line
+            /sbin/ip $proto $type replace $line
         fi
     done
 }

--- a/network-scripts/ifup-routes
+++ b/network-scripts/ifup-routes
@@ -2,6 +2,8 @@
 #
 # adds static routes which go through device $1
 
+. /etc/sysconfig/network-scripts/network-functions
+
 if [ -z "$1" ]; then
     echo $"usage: ifup-routes <net-device> [<nickname>]"
     exit 1
@@ -19,7 +21,12 @@ handle_file () {
             line="$line via $(eval echo '$'GATEWAY$routenum)"
         fi
         line="$line dev $2"
-        /sbin/ip route replace $line
+
+        /sbin/ip route add "$line" || { 
+            net_log $"Failed to add route ${line}, using ip route replace instead." warning
+            /sbin/ip route replace "$line"
+        }
+
         routenum=$(($routenum+1))
     done
 }
@@ -34,7 +41,10 @@ handle_ip_file() {
     fi
     { cat "$file" ; echo ; } | while read line; do
         if [[ ! "$line" =~ $MATCH ]]; then
-            /sbin/ip $proto $type replace $line
+            /sbin/ip $proto "$type" add "$line" || { 
+                net_log $"Failed to add ${type} ${line}, using ip ${type} replace instead." warning
+                /sbin/ip $proto "$type" replace "$line"
+            }
         fi
     done
 }


### PR DESCRIPTION
This should resolve the scenario when the link is brought
up prior to disabling accept_ra.

This only happens when both IPv4 and IPv6 address is on
the interface, because network-scripts does IPv4 first
and brings up the interface.

Then it does IPv6 which disables the RA's, at that point
the node has already learned the route from RA and setting
a default route fails.

Using `ip route replace` we ensure if the above scenario
happens we end-up with the correct default ipv6 route.

Huge thanks to Harald who debugged this issue and prepared a patch!

Resolves: #2034799

Co-authored-by: hjensas <hjensas@redhat.com>

(cherry picked from commit a71dcfd392cc1022c255208fdd94a0fc6c13ceb0)