### PR TITLE
spec: network-scripts needs to depend on dbus-tools for NetworkManager detection

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -114,6 +114,7 @@ Requires:         %{name}%{?_isa} = %{version}-%{release}
 
 Requires:         bc
 Requires:         dbus
+Requires:         dbus-tools
 Requires:         gawk
 Requires:         grep
 Requires:         hostname


### PR DESCRIPTION
How to reproduce:
```sh
(. /etc/sysconfig/network-scripts/network-functions; is_nm_running && echo "yes")
```

Resolves: #1832897

Co-authored-by: Till Maas <opensource@till.name>