### PR TITLE
spec: Drop unnecessary obsoletes

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -19,7 +19,7 @@ Requires:         gawk                       \
 Name:             initscripts
 Summary:          Basic support for legacy System V init scripts
 Version:          10.16
-Release:          1%{?dist}
+Release:          2%{?dist}
 
 License:          GPLv2
 
@@ -54,7 +54,7 @@ BuildRequires:    make
 %{?systemd_requires}
 BuildRequires:    systemd
 
-Obsoletes:        %{name}            < 10.10-1
+Obsoletes:        %{name}            < 10.16-1
 
 # === PATCHES =================================================================
 
@@ -95,8 +95,6 @@ Summary:          Udev helper utility that provides network interface naming
 
 %shared_requirements
 
-Obsoletes:        %{name}            < 10.16-1
-
 %description -n initscripts-rename-device
 Udev helper utility that provides network interface naming
 
@@ -111,8 +109,6 @@ BuildArch:        noarch
 Requires:         systemd
 
 Provides:         /sbin/service
-
-Obsoletes:        %{name}            < 10.10-1
 
 %description -n initscripts-service
 This package provides service command.
@@ -402,6 +398,9 @@ fi
 # =============================================================================
 
 %changelog
+* Wed Feb 23 2022 Adam Williamson <awilliam@redhat.com> - 10.16-2
+- Drop unnecessary obsoletes
+
 * Wed Feb 23 2022 Jan Macku <jamacku@redhat.com> - 10.16-1
 - spec: Move rename_device to subpackage `initscripts-rename-device`
 


### PR DESCRIPTION
Since initscripts requires these packages anyway, the obsoletes
aren't necessary. They're only useful if you split off a new
subpackage and *don't* have the main package require it, but
you still want it to be installed on updates. In this case,
initscripts requires both initscripts-rename-device and
initscripts-service, so there's no need for them to obsolete
older versions of it.

The initscripts-rename-device obsoletes was somehow messing up
live image creation during the openQA update test (caused the
live image not to include initscripts at all). This fixes that.

Signed-off-by: Adam Williamson <awilliam@redhat.com>

(cherry picked from commit 4e39c08825a55107a6accf7ad7b4d82ddd30e9ec)