### PR TITLE
(#2057917) spec: Move rename_device to subpackage initscripts-rename-device

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -54,7 +54,7 @@ BuildRequires:    make
 %{?systemd_requires}
 BuildRequires:    systemd
 
-Obsoletes:        %{name}            < 10.10-1
+Obsoletes:        %{name}            < 10.16-1
 
 # === PATCHES =================================================================
 
@@ -95,8 +95,6 @@ Summary:          Udev helper utility that provides network interface naming
 
 %shared_requirements
 
-Obsoletes:        %{name}            < 10.16-1
-
 %description -n initscripts-rename-device
 Udev helper utility that provides network interface naming
 
@@ -111,8 +109,6 @@ BuildArch:        noarch
 Requires:         systemd
 
 Provides:         /sbin/service
-
-Obsoletes:        %{name}            < 10.10-1
 
 %description -n initscripts-service
 This package provides service command.

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -36,6 +36,7 @@ Requires:         systemd
 Requires:         util-linux
 Requires:         chkconfig
 Requires:         initscripts-service
+Requires:         initscripts-rename-device
 
 Requires(pre):    shadow-utils
 Requires(post):   coreutils
@@ -88,6 +89,18 @@ This package provides basic support for legacy System V init scripts, and some
 other legacy tools & utilities.
 
 # === SUBPACKAGES =============================================================
+
+%package -n initscripts-rename-device
+Summary:          Udev helper utility that provides network interface naming
+
+%shared_requirements
+
+Obsoletes:        %{name}            < 10.16-1
+
+%description -n initscripts-rename-device
+Udev helper utility that provides network interface naming
+
+# ---------------
 
 %package -n initscripts-service
 Summary:          Support for service command
@@ -321,13 +334,18 @@ fi
 
 %{_prefix}/lib/systemd/system/import-state.service
 %{_prefix}/lib/systemd/system/loadmodules.service
-%{_prefix}/lib/udev/rename_device
-
-%{_udevrulesdir}/*
 
 %{_mandir}/man1/*
 
 # =============================================================================
+
+%files -n initscripts-rename-device
+
+%{_prefix}/lib/udev/rename_device
+
+%{_udevrulesdir}/*
+
+# ---------------
 
 %files -n initscripts-service
 


### PR DESCRIPTION
It allows to rename_device to be installed independently on initscripts.

(cherry picked from commit https://github.com/fedora-sysv/initscripts/commit/69a2526fa919a1ab215a4b19640b2214e0a1d78e)

Resolves: #2057917