### PR TITLE
Fix splitting spaces in paths from statetab files

### DIFF
--- a/usr/libexec/readonly-root
+++ b/usr/libexec/readonly-root
@@ -184,17 +184,17 @@ if is_true "$READONLY" || is_true "$TEMPORARY_STATE"; then
 				mount -n --bind $bindmountopts "$STATE_MOUNT/$file" "$file"
 			fi
 
-			for path in $(grep -v "^#" "$file" 2>/dev/null); do
+			while read path ; do
 				mount_state "$path"
 				selinux_fixup "$path"
-			done
+			done < <(grep -v "^#" "$file" 2>/dev/null)
 		done
 
 		if [ -f "$STATE_MOUNT/files" ] ; then
-			for path in $(grep -v "^#" "$STATE_MOUNT/files" 2>/dev/null); do
+			while read path ; do
 				mount_state "$path"
 				selinux_fixup "$path"
-			done
+			done < <(grep -v "^#" "$STATE_MOUNT/files" 2>/dev/null)
 		fi
 	fi
 

--- a/usr/libexec/readonly-root
+++ b/usr/libexec/readonly-root
@@ -96,7 +96,7 @@ if is_true "$READONLY" || is_true "$TEMPORARY_STATE"; then
 
 	for file in /etc/rwtab /etc/rwtab.d/* /run/initramfs/rwtab ; do
 		is_ignored_file "$file" && continue
-	[ -f $file ] && while read type path ; do
+	[ -f $file ] && while read -r type path ; do
 			case "$type" in
 				empty)
 					cp_empty $path
@@ -184,14 +184,14 @@ if is_true "$READONLY" || is_true "$TEMPORARY_STATE"; then
 				mount -n --bind $bindmountopts "$STATE_MOUNT/$file" "$file"
 			fi
 
-			while read path ; do
+			while read -r path ; do
 				mount_state "$path"
 				selinux_fixup "$path"
 			done < <(grep -v "^#" "$file" 2>/dev/null)
 		done
 
 		if [ -f "$STATE_MOUNT/files" ] ; then
-			while read path ; do
+			while read -r path ; do
 				mount_state "$path"
 				selinux_fixup "$path"
 			done < <(grep -v "^#" "$STATE_MOUNT/files" 2>/dev/null)


### PR DESCRIPTION
Noticed that paths with spaces in `/etc/statetab` and `/etc/statetab.d/*` weren't interpreted.
Since a for loop was used, bash just splitted paths at default IFS chars.

Since we could have paths with spaces like `/opt/my service` in statetab, we need to read the statetab files line per line, with IFS being '\n', which can be accomplished by using a while loop.
This is already done for rwtab.
