### PR TITLE
fedora: don't build network-scripts rpm in f40+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,11 @@ make-translations:
 #       just a symlink to /usr/bin, thanks to UsrMove change. Instead, we just
 #       use virtual provides for /usr/sbin/<utility> in specfile (for backward
 #       compatibility).
-install: install-binaries install-translations install-etc install-usr install-network-scripts install-man install-post
+ifdef NO_NETWORK_SCRIPTS
+install: install-binaries install-translations install-etc install-usr install-man install-post
+else
+install: install-binaries install-translations install-etc install-usr install-network-scripts install-man-all install-post
+endif
 
 
 install-binaries:
@@ -82,11 +86,19 @@ install-network-scripts: install-usr install-etc
 	ln -srf $(DESTDIR)$(sysconfdir)/sysconfig/network-scripts/{ifup-ippp,ifup-isdn}
 	ln -srf $(DESTDIR)$(sysconfdir)/sysconfig/network-scripts/{ifdown-ippp,ifdown-isdn}
 
+install-man-all: install-man install-network-scripts-man
+
 install-man: install-usr
 	install -m 0755 -d      $(DESTDIR)$(mandir)/man1
 	install -m 0755 -d      $(DESTDIR)$(mandir)/man8
-	install -m 0644 man/*.1 $(DESTDIR)$(mandir)/man1
-	install -m 0644 man/*.8 $(DESTDIR)$(mandir)/man8
+	install -m 0644 man/consoletype.1 $(DESTDIR)$(mandir)/man1
+	install -m 0644 man/genhostid.1   $(DESTDIR)$(mandir)/man1
+	install -m 0644 man/usleep.1      $(DESTDIR)$(mandir)/man1
+	install -m 0644 man/service.8     $(DESTDIR)$(mandir)/man8
+
+install-network-scripts-man:
+	install -m 0644 man/ifup.8        $(DESTDIR)$(mandir)/man8
+	install -m 0644 man/usernetctl.8  $(DESTDIR)$(mandir)/man8
 
 # Initscripts still ship some empty directories necessary for system to function
 # correctly...

--- a/initscripts.spec
+++ b/initscripts.spec
@@ -55,6 +55,7 @@ BuildRequires:    make
 BuildRequires:    systemd
 
 Obsoletes:        %{name}            < 10.16-1
+Obsoletes:        network-scripts    <= 10.20-1
 
 # === PATCHES =================================================================
 
@@ -112,57 +113,6 @@ Provides:         /sbin/service
 
 %description -n initscripts-service
 This package provides service command.
-
-# ---------------
-
-%package -n network-scripts
-Summary:          Legacy scripts for manipulating of network devices
-Requires:         %{name}%{?_isa} = %{version}-%{release}
-
-%shared_requirements
-
-Requires:         bc
-Requires:         dbus
-Requires:         dbus-tools
-Requires:         gawk
-Requires:         grep
-Requires:         hostname
-Requires:         iproute
-Requires:         ipcalc
-Requires:         kmod
-Requires:         procps-ng
-Requires:         sed
-Requires:         systemd
-
-Requires(post):   chkconfig
-Requires(preun):  chkconfig
-
-Requires(post):   %{_sbindir}/update-alternatives
-Requires(postun): %{_sbindir}/update-alternatives
-
-Obsoletes:        %{name}            < 9.82-2
-
-# This is legacy and deprecated, so nobody should depend on this!
-# If ifcfg-style configuration is still desired, NetworkManager can do this.
-# Thus, mark this as deprecated to ensure people know to not depend on it.
-# Cf. https://docs.fedoraproject.org/en-US/packaging-guidelines/deprecating-packages/
-Provides:         deprecated()
-
-%description -n network-scripts
-This package contains the legacy scripts for activating & deactivating of most
-network interfaces. It also provides a legacy version of 'network' service.
-
-The 'network' service is enabled by default after installation of this package,
-and if the network-scripts are installed alongside NetworkManager, then the
-ifup/ifdown commands from network-scripts take precedence over the ones provided
-by NetworkManager.
-
-If user has both network-scripts & NetworkManager installed, and wishes to
-use ifup/ifdown from NetworkManager primarily, then they has to run command:
- $ update-alternatives --config ifup
-
-Please note that running the command above will also disable the 'network'
-service.
 
 # ---------------
 
@@ -225,24 +175,10 @@ Please use systemd-volatile-root functionality instead, if possible.
 # ---------------
 
 %install
-%make_install
+%make_install NO_NETWORK_SCRIPTS=true
 
 # This installs the NLS language files:
 %find_lang %{name}
-
-%ifnarch s390 s390x
-  rm -f %{buildroot}%{_sysconfdir}/sysconfig/network-scripts/ifup-ctc
-%endif
-
-# Additional ways to access documentation:
-install -m 0755 -d %{buildroot}%{_docdir}/network-scripts
-
-ln -s  %{_docdir}/%{name}/sysconfig.txt %{buildroot}%{_docdir}/network-scripts/
-ln -sr %{_mandir}/man8/ifup.8           %{buildroot}%{_mandir}/man8/ifdown.8
-
-# We are now using alternatives approach to better co-exist with NetworkManager:
-touch %{buildroot}%{_sbindir}/ifup
-touch %{buildroot}%{_sbindir}/ifdown
 
 # =============================================================================
 
@@ -254,24 +190,6 @@ touch %{buildroot}%{_sbindir}/ifdown
 
 %postun
 %systemd_postun import-state.service loadmodules.service
-
-# ---------------
-
-%post -n network-scripts
-chkconfig --add network > /dev/null 2>&1 || :
-
-[ -L %{_sbindir}/ifup ]   || rm -f %{_sbindir}/ifup
-[ -L %{_sbindir}/ifdown ] || rm -f %{_sbindir}/ifdown
-
-%{_sbindir}/update-alternatives --install %{_sbindir}/ifup   ifup   %{_sysconfdir}/sysconfig/network-scripts/ifup 90 \
-                                --slave   %{_sbindir}/ifdown ifdown %{_sysconfdir}/sysconfig/network-scripts/ifdown \
-                                --initscript network
-
-%preun -n network-scripts
-if [ $1 -eq 0 ]; then
-  chkconfig --del network > /dev/null 2>&1 || :
-  %{_sbindir}/update-alternatives --remove ifup %{_sysconfdir}/sysconfig/network-scripts/ifup
-fi
 
 # ---------------
 
@@ -352,26 +270,6 @@ fi
 %{_sbindir}/service
 
 %{_mandir}/man8/service.*
-
-# ---------------
-
-%files -n network-scripts
-%doc doc/examples/
-%dir %{_sysconfdir}/sysconfig/network-scripts
-
-%{_sysconfdir}/rc.d/init.d/network
-%{_sysconfdir}/sysconfig/network-scripts/*
-
-%config(noreplace)    %{_sysconfdir}/sysconfig/network-scripts/ifcfg-lo
-
-%ghost                %{_sbindir}/ifup
-%ghost                %{_sbindir}/ifdown
-%attr(4755,root,root) %{_sbindir}/usernetctl
-
-%{_mandir}/man8/ifup.*
-%{_mandir}/man8/ifdown.*
-%{_mandir}/man8/usernetctl.*
-%{_docdir}/network-scripts/*
 
 # ---------------
 


### PR DESCRIPTION
`network-scripts` have been deprecated for a long time. It's time to drop them from Fedora.

Everybody should use `NetworkManager` or `systemd-networkd` instead.

Resolves: #2262795