### PR TITLE
ifup-routes: print warning when ADDRESS0 entry is missing

### DIFF
--- a/network-scripts/ifup-routes
+++ b/network-scripts/ifup-routes
@@ -14,6 +14,13 @@ MATCH='^[[:space:]]*(\#.*)?$'
 handle_file () {
     . $1
     routenum=0
+
+    # print a warning if ADDRESS is not starting at ADDRESS0
+    if [ "x$(eval echo '$'ADDRESS$routenum)x" == "xx" ]; then
+        net_log $"Route entries are not sequentially ordered. Skipping $1 file" warning
+        exit 1
+    fi
+        
     while [ "x$(eval echo '$'ADDRESS$routenum)x" != "xx" ]; do
         eval $(ipcalc -p $(eval echo '$'ADDRESS$routenum) $(eval echo '$'NETMASK$routenum))
         line="$(eval echo '$'ADDRESS$routenum)/$PREFIX"


### PR DESCRIPTION
When static routes are added via route-<interface> file, the ifup-routes script will skip adding routes if entries not starting with ADDRESS0.

Good to print a warning so that users are aware of this.