### PR TITLE
Fix build when %_bindir==%_sbindir

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -244,6 +244,11 @@ ln -sr %{_mandir}/man8/ifup.8           %{buildroot}%{_mandir}/man8/ifdown.8
 touch %{buildroot}%{_sbindir}/ifup
 touch %{buildroot}%{_sbindir}/ifdown
 
+%if "%{_sbindir}" == "%{_bindir}"
+# Some files get installed wrong, but if $(sbindir) is overriden, the build fails :(
+mv -v %{buildroot}/usr/sbin/* %{buildroot}%{_bindir}/
+%endif
+
 # =============================================================================
 
 %post
@@ -322,7 +327,7 @@ fi
 
 # ---------------
 
-%{_bindir}/*
+%{_bindir}/usleep
 %{_sbindir}/consoletype
 %{_sbindir}/genhostid
 


### PR DESCRIPTION
Preparation for https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin. The glob in %files wase causing a warning about duplicate entries in %files.