### PR TITLE
network-functions: Fix a bug in is_nm_handling()

### DIFF
--- a/network-scripts/network-functions
+++ b/network-scripts/network-functions
@@ -302,7 +302,7 @@ is_nm_active ()
 
 is_nm_handling ()
 {
-    LANG=C nmcli -t --fields device,state dev status 2>/dev/null | grep -q "^\(${1}:connected\)\|\(${1}:connecting.*\)$"
+    LANG=C nmcli -t --fields device,state dev status 2>/dev/null | grep -q "^\(${1}:connected\|${1}:connecting.*\)$"
 }
 
 is_nm_device_unmanaged ()


### PR DESCRIPTION
Currently the "^" anchor is applied to the "connected" case and does not apply to the "connecting" case in the grep due to the way the brackets () are placed. This can cause the grep statement to incorrectly return a match.

For ex: When trying to check for eth0 using is_nm_handling(), "bondeth0:connecting" would also match the grep and return incorrectly.