### PR TITLE
man: add ifdown.8

### DIFF
--- a/man/ifdown.8
+++ b/man/ifdown.8
@@ -1,0 +1,1 @@
+.so man8/ifup.8


### PR DESCRIPTION
Let's add ifdown.8 man page that sources from ifup.8 to remove need of creating symlink to ifup.8.

This caused previously issues like:

```sh
ls -la /usr/share/man/man8/ifdown.8.gz
lrwxrwxrwx. 1 root root 52 Aug 10  2022 /usr/share/man/man8/ifdown.8.gz -> ../../../../../../../../usr/share/man/man8/ifup.8.gz
```

Fixes: https://github.com/fedora-sysv/initscripts/commit/665d560efebeb05dbc70e859ae67ee9415775b32