### PR TITLE
man: add ifdown.8

### DIFF
--- a/initscripts.spec
+++ b/initscripts.spec
@@ -202,7 +202,6 @@ support. Additional configuration is required after installation.
 install -m 0755 -d %{buildroot}%{_docdir}/network-scripts
 
 ln -s  %{_docdir}/%{name}/sysconfig.txt %{buildroot}%{_docdir}/network-scripts/
-ln -sr %{_mandir}/man8/ifup.8           %{buildroot}%{_mandir}/man8/ifdown.8
 
 # We are now using alternatives approach to better co-exist with NetworkManager:
 touch %{buildroot}%{_sbindir}/ifup

--- a/man/ifdown.8
+++ b/man/ifdown.8
@@ -1,0 +1,1 @@
+.so man8/ifup.8


### PR DESCRIPTION
Let's add ifdown.8 man page that sources from ifup.8 to remove need of creating symlink to ifup.8.

This caused previously issues like:
```sh
ls -la /usr/share/man/man8/ifdown.8.gz
lrwxrwxrwx. 1 root root 52 Aug 10  2022 /usr/share/man/man8/ifdown.8.gz -> ../../../../../../../../usr/share/man/man8/ifup.8.gz
```

Fixes: https://github.com/fedora-sysv/initscripts/commit/665d560efebeb05dbc70e859ae67ee9415775b32 (cherry picked from commit 080801f38765d93ea6e355dcab0377c3e71a4869)

Resolves: RHEL-112178